### PR TITLE
Adjust powerup sequence

### DIFF
--- a/doc/xtrx/xtrx_boot_powerup.txt
+++ b/doc/xtrx/xtrx_boot_powerup.txt
@@ -1,0 +1,152 @@
+# This is an annotated boot powerup log of the XTRX original firmware.
+# The annotations are to link back to the original XTRX firmware source,
+# and is summarized in the large comment in our firmware's `main.c`.
+
+julia> include("software/scripts/xtrx_reg_dump.jl")
+[ Info: Precompiling xtrx_jll [f7ce82bc-bc1e-5125-bd1d-6a84dd39bfb4]
+ccall((:xtrxll_get_loglevel, xtrx_jll.libxtrxll), Int, ()) = 4
+[INFO] Make connection: 'pcie:///dev/xtrx0'
+21:05:40.006807 INFO:   [XTRX] xtrx_open(): dev[0]='pcie:///dev/xtrx0'
+21:05:40.006859 INFO:   [CTRL] PCI:/dev/xtrx0: RFIC_GPIO 0x000300
+
+# -> lp8758_set(dev, XTRX_I2C_PMIC_LMS, BUCK1_CTRL1, PMIC_CH_ENABLE)
+lp8758_set(0x03, 0x04, 0x88) -> (status 0)
+
+lp8758_get(0x03, 0x00) -> 0x01 (status 0)
+lp8758_get(0x03, 0x01) -> 0xe0 (status 0)
+lp8758_get(0x00, 0x00) -> 0x00 (status 0)
+lp8758_get(0x00, 0x01) -> 0x00 (status 0)
+lp8758_get(0x00, 0x00) -> 0x00 (status 0)
+lp8758_get(0x00, 0x01) -> 0x00 (status 0)
+lp8758_get(0x00, 0x00) -> 0x00 (status 0)
+lp8758_get(0x00, 0x01) -> 0x00 (status 0)
+lp8758_get(0x00, 0x00) -> 0x00 (status 0)
+lp8758_get(0x00, 0x01) -> 0xe0 (status 0)
+lp8758_get(0x00, 0x00) -> 0x01 (status 0)
+lp8758_get(0x00, 0x01) -> 0xe0 (status 0)
+
+# -> lp8758_set(dev, XTRX_I2C_PMIC_LMS, BUCK0_CTRL1, PMIC_CH_DISABLE);
+lp8758_set(0x03, 0x02, 0xc8) -> (status 0)
+# -> lp8758_set(dev, XTRX_I2C_PMIC_LMS, BUCK2_CTRL1, PMIC_CH_DISABLE);
+lp8758_set(0x03, 0x06, 0xc8) -> (status 0)
+# -> lp8758_set(dev, XTRX_I2C_PMIC_LMS, BUCK3_CTRL1, PMIC_CH_DISABLE);
+lp8758_set(0x03, 0x08, 0xc8) -> (status 0)
+
+21:05:40.024169 INFO:   [CTRL] PCI:/dev/xtrx0: RFIC_GPIO 0x008300
+21:05:40.024758 INFO:   [CTRL] PCI:/dev/xtrx0: XTRX Rev5 (04000113)
+21:05:40.024772 INFO:   [BPCI] PCI:/dev/xtrx0: RX DMA STOP MIMO (BLK:0 TS:0); TX DMA STOP MIMO @0.0
+21:05:40.024775 INFO:   [PCIE] PCI:/dev/xtrx0: Device `pcie:///dev/xtrx0` has been opened successfully
+CPU Features: SSE2+ SSE4.1+ AVX+ FMA+
+
+# xtrxll_set_param(XTRXLL_PARAM_PWR_CTRL, PWR_CTRL_BUSONLY)
+PCI:/dev/xtrx0: set_param 8 0x1
+
+# -> lp8758_set(dev, XTRX_I2C_PMIC_LMS, BUCK1_CTRL1, PMIC_CH_ENABLE)
+lp8758_set(0x03, 0x04, 0x88) -> (status 0)
+lp8758_get(0x03, 0x00) -> 0x01 (status 0)
+lp8758_get(0x03, 0x01) -> 0xe0 (status 0)
+lp8758_get(0x00, 0x00) -> 0x01 (status 0)
+lp8758_get(0x00, 0x01) -> 0xe0 (status 0)
+
+# -> lp8758_set(dev, XTRX_I2C_PMIC_LMS, BUCK0_CTRL1, PMIC_CH_DISABLE);
+lp8758_set(0x03, 0x02, 0xc8) -> (status 0)
+# -> lp8758_set(dev, XTRX_I2C_PMIC_LMS, BUCK2_CTRL1, PMIC_CH_DISABLE);
+lp8758_set(0x03, 0x06, 0xc8) -> (status 0)
+# -> lp8758_set(dev, XTRX_I2C_PMIC_LMS, BUCK3_CTRL1, PMIC_CH_DISABLE);
+lp8758_set(0x03, 0x08, 0xc8) -> (status 0)
+
+# xtrxll_set_param(XTRXLL_PARAM_FE_CTRL, XTRXLL_LMS7_GPWR_PIN)
+PCI:/dev/xtrx0: set_param 9 0x4
+21:05:40.138375 INFO:   [CTRL] PCI:/dev/xtrx0: RFIC_GPIO 0x008304
+
+# xtrxll_set_param(XTRXLL_PARAM_PWR_CTRL, PWR_CTRL_ON)
+PCI:/dev/xtrx0: set_param 8 0x2
+
+# -> lp8758_set(dev, XTRX_I2C_PMIC_LMS, BUCK1_VOUT, 0xfb)
+lp8758_set(0x03, 0x0c, 0xfb) -> (status 0)
+21:05:40.238692 INFO:   [CTRL] PCI:/dev/xtrx0: FPGA V_GPIO set to 3280mV
+
+# -> lp8758_set(dev, XTRX_I2C_PMIC_LMS, BUCK0_VOUT, get_voltage(V_LMS_1V8 + extra_drop))
+lp8758_set(0x03, 0x0a, 0xb5) -> (status 0)
+# -> lp8758_set(dev, XTRX_I2C_PMIC_LMS, BUCK2_VOUT, get_voltage(V_LMS_1V4 + extra_drop))
+lp8758_set(0x03, 0x0e, 0xa1) -> (status 0)
+# -> lp8758_set(dev, XTRX_I2C_PMIC_LMS, BUCK3_VOUT, get_voltage(V_LMS_1V2 + extra_drop))
+lp8758_set(0x03, 0x10, 0x92) -> (status 0)
+
+21:05:40.238732 INFO:   [CTRL] PCI:/dev/xtrx0: LMS PMIC DCDC out set to VA18=1880mV VA14=1480mV VA12=1340mV
+
+# -> lp8758_set(dev, XTRX_I2C_PMIC_LMS, BUCK1_CTRL1, PMIC_CH_ENABLE);
+lp8758_set(0x03, 0x04, 0x88) -> (status 0)
+lp8758_get(0x03, 0x00) -> 0x01 (status 0)
+lp8758_get(0x03, 0x01) -> 0xe0 (status 0)
+lp8758_get(0x00, 0x00) -> 0x01 (status 0)
+lp8758_get(0x00, 0x01) -> 0xe0 (status 0)
+
+# -> lp8758_set(dev, XTRX_I2C_PMIC_LMS, BUCK0_CTRL1, PMIC_CH_ENABLE);
+lp8758_set(0x03, 0x02, 0x88) -> (status 0)
+# -> lp8758_set(dev, XTRX_I2C_PMIC_LMS, BUCK2_CTRL1, PMIC_CH_ENABLE);
+lp8758_set(0x03, 0x06, 0x88) -> (status 0)
+# -> lp8758_set(dev, XTRX_I2C_PMIC_LMS, BUCK3_CTRL1, PMIC_CH_ENABLE);
+lp8758_set(0x03, 0x08, 0x88) -> (status 0)
+
+# -> lp8758_set(dev, XTRX_I2C_PMIC_FPGA, BUCK1_VOUT, get_voltage(vio_mv))
+lp8758_set(0x00, 0x0c, 0xb1) -> (status 0)
+21:05:40.242290 INFO:   [CTRL] PCI:/dev/xtrx0: FPGA V_IO set to 1800mV
+
+# xtrxll_set_param(XTRXLL_PARAM_FE_CTRL, XTRXLL_LMS7_GPWR_PIN | XTRXLL_LMS7_RESET_PIN)
+PCI:/dev/xtrx0: set_param 9 0x6
+21:05:40.252440 INFO:   [CTRL] PCI:/dev/xtrx0: RFIC_GPIO 0x008306
+21:05:40.263634 INFO:   [LSM7] PCI:/dev/xtrx0: LMS VER:7 REV:1 MASK:1 (3841)
+# xtrxll_set_param(XTRXLL_PARAM_FE_CTRL, XTRXLL_LMS7_GPWR_PIN | XTRXLL_LMS7_RESET_PIN | XTRXLL_LMS7_RXEN_PIN | XTRXLL_LMS7_TXEN_PIN)
+PCI:/dev/xtrx0: set_param 9 0x1e
+21:05:40.263683 INFO:   [CTRL] PCI:/dev/xtrx0: RFIC_GPIO 0x00831e
+[INFO] Created: `pcie:///dev/xtrx0`
+21:05:41.081503 INFO:   [BPCI] PCI:/dev/xtrx0: RX DMA STOP MIMO (BLK:0 TS:0); TX DMA SKIP MIMO @0.0
+21:05:41.081578 INFO:   [LSM7] PCI:/dev/xtrx0: 0x0124[00, 00]
+21:05:41.081828 INFO:   [BPCI] PCI:/dev/xtrx0: RX DMA STOP MIMO (BLK:0 TS:0); TX DMA SKIP MIMO @0.0
+21:05:41.081837 INFO:   [LMSF] PCI:/dev/xtrx0: Auto RX band selection: LNAL
+21:05:41.081840 INFO:   [LMSF] PCI:/dev/xtrx0: Set RX band to 2 (L)
+PCI:/dev/xtrx0: set_param 6 0x1
+21:05:41.082146 INFO:   [CTRL] PCI:/dev/xtrx0: RX_ANT: 1 TX_ANT: 0
+21:05:41.082147 INFO:   [LMSF] PCI:/dev/xtrx0: DC START
+21:05:41.082215 INFO:   [LSM7] PCI:/dev/xtrx0:  5c1=0000
+21:05:41.082239 INFO:   [LSM7] PCI:/dev/xtrx0:  5c1=0000
+21:05:41.082249 INFO:   [LSM7] PCI:/dev/xtrx0:  5c1=0000
+21:05:41.082258 INFO:   [LSM7] PCI:/dev/xtrx0:  5c1=0000
+21:05:41.082280 INFO:   [LSM7] PCI:/dev/xtrx0:  5c1=0000
+21:05:41.082303 INFO:   [LSM7] PCI:/dev/xtrx0:  5c1=0000
+21:05:41.082312 INFO:   [LSM7] PCI:/dev/xtrx0:  5c1=0000
+21:05:41.082321 INFO:   [LSM7] PCI:/dev/xtrx0:  5c1=0000
+21:05:41.082330 INFO:   [LSM7] PCI:/dev/xtrx0:  5c1=0000
+21:05:41.082338 INFO:   [LSM7] PCI:/dev/xtrx0:  5c1=0000
+21:05:41.082362 INFO:   [LSM7] PCI:/dev/xtrx0:  TX[0]=0000
+21:05:41.082386 INFO:   [LSM7] PCI:/dev/xtrx0:  TX[1]=0000
+21:05:41.082409 INFO:   [LSM7] PCI:/dev/xtrx0:  TX[2]=0000
+21:05:41.082433 INFO:   [LSM7] PCI:/dev/xtrx0:  TX[3]=0000
+21:05:41.082489 INFO:   [LSM7] PCI:/dev/xtrx0:  RX[0]=0000
+21:05:41.082513 INFO:   [LSM7] PCI:/dev/xtrx0:  RX[1]=0000
+21:05:41.082536 INFO:   [LSM7] PCI:/dev/xtrx0:  RX[2]=0000
+21:05:41.082560 INFO:   [LSM7] PCI:/dev/xtrx0:  RX[3]=0000
+ccall((:xtrxll_get_loglevel, xtrx_jll.libxtrxll), Int, ()) = 4
+┌ Warning: readStream timeout!
+│   timeout = 0.1
+│   total_nread = -991520
+│   samples_to_read = 100000
+│   flags = "WAIT_TRIGGER,MORE_FRAGMENTS"
+└ @ SoapySDR ~/.julia/packages/SoapySDR/eBvoR/src/highlevel.jl:698
+PCI:/dev/xtrx0: set_param 10 (nil)
+21:05:42.375479 INFO:   [CTRL] PCI:/dev/xtrx0: RFIC_GPIO 0x00831e
+21:05:42.385781 INFO:   [XTRX] PCI:/dev/xtrx0: Set INT RefClk to 26000000 based on 26060461 measurement
+21:05:42.385800 INFO:   [LMSF] PCI:/dev/xtrx0: Increase RXdiv= 0 TXdiv= 8 => CGEN 8.0 Mhz
+21:05:42.385827 INFO:   [LMSF] PCI:/dev/xtrx0: Increase RXdiv= 0 TXdiv=16 => CGEN 16.0 Mhz
+21:05:42.385829 INFO:   [LMSF] PCI:/dev/xtrx0: Increase RXdiv= 0 TXdiv=32 => CGEN 32.0 Mhz
+21:05:42.385838 INFO:   [LSM7] PCI:/dev/xtrx0: CGEN: VCO/2=1184000000 k/2=37 int=91 frac=80659
+21:05:42.386451 INFO:   [LSM7] PCI:/dev/xtrx0: CGEN: binary result: 159
+21:05:42.386574 INFO:   [LSM7] PCI:/dev/xtrx0: CGEN: Retuned [159:165] -> 162
+PCI:/dev/xtrx0: set_param 9 0x1e
+21:05:42.386675 INFO:   [CTRL] PCI:/dev/xtrx0: RFIC_GPIO 0x00831e
+PCI:/dev/xtrx0: set_param 2 0x708
+lp8758_set(0x00, 0x0c, 0xb1) -> (status 0)
+21:05:42.386697 INFO:   [CTRL] PCI:/dev/xtrx0: FPGA V_IO set to 1800mV
+21:05:42.386700 INFO:   [LMSF] PCI:/dev/xtrx0: rxrate=0.000MHz txrate=1.000MHz actual_master=32.000MHz rxdecim=1(h_1) txinterp=32(h_1) RX_ADC=8.000MHz TX_DAC=32.000MHz hintr=0 hdecim=0 delay=0 NRXFWD=0 LML1HID=3 LML2HID=1 RX_div=0 TX_div=0 RX_TSP_div=1 TX_TSP_div=16 FclkRX=0.000 (PHS=0) RXx2=0
+1 MHz

--- a/firmware/main.c
+++ b/firmware/main.c
@@ -462,11 +462,6 @@ static int xtrx_init(void)
 	dat = 0x88;
 	i2c0_write(LP8758_I2C_ADDR, adr, &dat, 1);
 
-	printf("PMIC-LMS: Set Buck1 to 3280mV.\n");
-	adr = 0x0c;
-	dat = 0xfb;
-	i2c0_write(LP8758_I2C_ADDR, adr, &dat, 1);
-
 	// lp8758_set(dev, XTRX_I2C_PMIC_LMS, BUCK0_CTRL1, PMIC_CH_DISABLE);
 	printf("PMIC-LMS: Disable Buck0.\n");
 	adr = 0x02;
@@ -485,50 +480,12 @@ static int xtrx_init(void)
 	dat = 0xc8;
 	i2c0_write(LP8758_I2C_ADDR, adr, &dat, 1);
 
-	printf("PMIC-LMS: Set Buck0 to 1880mV.\n");
-	adr = 0x0a;
-	dat = 0xb5;
-	i2c0_write(LP8758_I2C_ADDR, adr, &dat, 1);
-
-	printf("PMIC-LMS: Set Buck2 to 1480mV.\n");
-	adr = 0x0e;
-	dat = 0xa1;
-	i2c0_write(LP8758_I2C_ADDR, adr, &dat, 1);
-
-	printf("PMIC-LMS: Set Buck3 to 1340mV.\n");
-	adr = 0x10;
-	dat = 0x92;
-	i2c0_write(LP8758_I2C_ADDR, adr, &dat, 1);
-
 	busy_wait(10);
 
 	// Check that the PMIC is alive
 	if (assert_pmic_alive() != 0) {
 		return -1;
 	}
-
-	printf("PMIC-LMS: Enable Buck0.\n");
-	adr = 0x02;
-	dat = 0x88;
-	i2c0_write(LP8758_I2C_ADDR, adr, &dat, 1);
-
-	printf("PMIC-LMS: Enable Buck2.\n");
-	adr = 0x06;
-	dat = 0x88;
-	i2c0_write(LP8758_I2C_ADDR, adr, &dat, 1);
-
-	printf("PMIC-LMS: Enable Buck3.\n");
-	adr = 0x08;
-	dat = 0x88;
-	i2c0_write(LP8758_I2C_ADDR, adr, &dat, 1);
-
-	printf("PMIC-FPGA: Set Buck1 to 3280mV.\n");
-	adr = 0x0c;
-	dat = 0xfb;
-	i2c1_write(LP8758_I2C_ADDR, adr, &dat, 1);
-
-	// Give the bucks some time to settle before bringing up the LMS7002m
-	busy_wait(100);
 
 	/* Get board revision */
 	printf("\n");
@@ -556,9 +513,53 @@ static int xtrx_init(void)
 	printf("LMS7002M Power-Down.\n");
 	lms7002m_control_write(LMS7002M_RESET | LMS7002M_POWER_DOWN);
 	busy_wait(100);
+
 	printf("LMS7002M Reset.\n");
 	lms7002m_control_write(LMS7002M_RESET);
 	busy_wait(10);
+
+	printf("PMIC-FPGA: Set Buck1 to 3280mV.\n");
+	adr = 0x0c;
+	dat = 0xfb;
+	i2c1_write(LP8758_I2C_ADDR, adr, &dat, 1);
+
+	printf("PMIC-LMS: Set Buck0 to 1880mV.\n");
+	adr = 0x0a;
+	dat = 0xb5;
+	i2c0_write(LP8758_I2C_ADDR, adr, &dat, 1);
+
+	printf("PMIC-LMS: Set Buck2 to 1480mV.\n");
+	adr = 0x0e;
+	dat = 0xa1;
+	i2c0_write(LP8758_I2C_ADDR, adr, &dat, 1);
+
+	printf("PMIC-LMS: Set Buck3 to 1340mV.\n");
+	adr = 0x10;
+	dat = 0x92;
+	i2c0_write(LP8758_I2C_ADDR, adr, &dat, 1);
+
+	printf("PMIC-LMS: Enable Buck0.\n");
+	adr = 0x02;
+	dat = 0x88;
+	i2c0_write(LP8758_I2C_ADDR, adr, &dat, 1);
+
+	printf("PMIC-LMS: Enable Buck2.\n");
+	adr = 0x06;
+	dat = 0x88;
+	i2c0_write(LP8758_I2C_ADDR, adr, &dat, 1);
+
+	printf("PMIC-LMS: Enable Buck3.\n");
+	adr = 0x08;
+	dat = 0x88;
+	i2c0_write(LP8758_I2C_ADDR, adr, &dat, 1);
+
+	printf("PMIC-LMS: Set Buck1 to 1800mV.\n");
+	adr = 0x0c;
+	dat = 0xb1;
+	i2c0_write(LP8758_I2C_ADDR, adr, &dat, 1);
+
+	busy_wait(100);
+
 	printf("LMS7002M TX/RX Enable.\n");
 	lms7002m_control_write(LMS7002M_TX_ENABLE | LMS7002M_RX_ENABLE);
 

--- a/firmware/main.c
+++ b/firmware/main.c
@@ -341,9 +341,106 @@ static void digi_1v8(void)
 	i2c1_write(LP8758_I2C_ADDR, adr, &dat, 1);
 }
 
+// Checks that the PMIC is alive and responding to commands as we expect.
+static int check_pmic_id() {
+	unsigned char address = 0x0, data = 0x0;
+
+	// Ask for register 0x00: Hardware ID
+	address = 0x0;
+	i2c1_read(LP8758_I2C_ADDR, address, &data, 1, true);
+	if (data != 0x01) {
+		return -1;
+	}
+	// Ask for register 0x01: EEPROM ID
+	address = 0x1;
+	i2c1_read(LP8758_I2C_ADDR, address, &data, 1, true);
+	if (data != 0xe0) {
+		return -1;
+	}
+	return 0;
+}
+
+static int assert_pmic_alive() {
+	printf("PMIC: Check ID...");
+	if (check_pmic_id() != 0) {
+		printf("NOT OK! Bailing!\n");
+		return -1;
+	}
+	printf("OK\n");
+	return 0;
+}
+
 /*-----------------------------------------------------------------------*/
 /* Init                                                                  */
 /*-----------------------------------------------------------------------*/
+
+/*
+
+@subroutine lp8758_en(en_lms=0, en_b33=1)
+	-> lp8758_set(dev, XTRX_I2C_PMIC_LMS, BUCK1_CTRL1, PMIC_CH_ENABLE);
+	-> lp8758_get(dev->self, XTRX_I2C_PMIC_LMS, DEV_REV, (uint8_t*)&v);
+	-> lp8758_get(dev->self, XTRX_I2C_PMIC_LMS, OTP_REV, (uint8_t*)&d);
+		-> print out "PMIC_L ver %02x:%02x  en33=1"
+	-> lp8758_set(dev, XTRX_I2C_PMIC_LMS, BUCK0_CTRL1, PMIC_CH_DISABLE);
+	-> lp8758_set(dev, XTRX_I2C_PMIC_LMS, BUCK2_CTRL1, PMIC_CH_DISABLE);
+	-> lp8758_set(dev, XTRX_I2C_PMIC_LMS, BUCK3_CTRL1, PMIC_CH_DISABLE);
+
+
+@subroutine lp8758_en(en_lms=1, en_b33=1)
+	-> _xtrxllr3_pmic_lms_set(dev, XTRX_PWR_ECONOMY * XTRX_PWR_V_DROP);
+		-> _xtrxllr3_gpio_set(dev, V_XTRX_XO + extra_drop)
+			-> lp8758_set(dev, XTRX_I2C_PMIC_LMS, BUCK1_VOUT, get_voltage(vgpio_mv));
+			-> print out "FPGA V_IO set to 3280mV"
+		-> lp8758_set(dev, XTRX_I2C_PMIC_LMS, BUCK0_VOUT, get_voltage(V_LMS_1V8 + extra_drop));
+		-> lp8758_set(dev, XTRX_I2C_PMIC_LMS, BUCK2_VOUT, get_voltage(V_LMS_1V4 + extra_drop));
+		-> lp8758_set(dev, XTRX_I2C_PMIC_LMS, BUCK3_VOUT, get_voltage(V_LMS_1V2 + extra_drop));
+		-> print out "LMS PMIC DCDC out set to VA18=1880mV VA14=1480mV VA12=1340mV"
+	-> lp8758_set(dev, XTRX_I2C_PMIC_LMS, BUCK1_CTRL1, PMIC_CH_ENABLE);
+	-> lp8758_get(dev->self, XTRX_I2C_PMIC_LMS, DEV_REV, (uint8_t*)&v);
+	-> lp8758_get(dev->self, XTRX_I2C_PMIC_LMS, OTP_REV, (uint8_t*)&d);
+		-> print out "PMIC_L ver %02x:%02x  en33=1"
+	-> lp8758_set(dev, XTRX_I2C_PMIC_LMS, BUCK0_CTRL1, PMIC_CH_ENABLE);
+	-> lp8758_set(dev, XTRX_I2C_PMIC_LMS, BUCK2_CTRL1, PMIC_CH_ENABLE);
+	-> lp8758_set(dev, XTRX_I2C_PMIC_LMS, BUCK3_CTRL1, PMIC_CH_ENABLE);
+	-> _xtrxllr3_io_set(vio_mv=1800)
+		-> lp8758_set(dev, XTRX_I2C_PMIC_FPGA, BUCK1_VOUT, get_voltage(vio_mv));
+		-> print out "FPGA V_IO set to 1800mV"
+
+XTRX init procedure:
+	- xtrx_open()
+		- xtrxll_open() -> xtrxll_base_dev_init()
+			-> lp8758_en(dev, 0, 1)
+			-> wait 10ms
+		- xtrx_fe_init() -> lms7nfe_init()
+			-> wait 10ms
+		- xtrxll_set_param(XTRXLL_PARAM_PWR_CTRL, PWR_CTRL_BUSONLY)
+			-> lp8758_en(dev, 0, 1)
+			-> wait 100ms
+		- xtrxll_set_param(XTRXLL_PARAM_FE_CTRL, XTRXLL_LMS7_GPWR_PIN)
+			-> W17 high
+			-> wait 100ms
+		- xtrxll_set_param(XTRXLL_PARAM_PWR_CTRL, PWR_CTRL_ON)
+			-> lp8758_en(dev, 1, 1)
+			-> wait 10ms
+		- xtrxll_set_param(XTRXLL_PARAM_FE_CTRL, XTRXLL_LMS7_GPWR_PIN | XTRXLL_LMS7_RESET_PIN)
+			-> U19 high 
+			-> W17 high
+			-> wait 10ms
+	
+		# Thought: limesuite should probably handle this?
+		- lms7_enable()
+			-> lms7_reset()
+				-> SPI [0x20] = 0x02
+				-> SPI [0x20] = 0xff
+			-> lms7_ldo_enable()
+			-> lms7_xbuf_enable()
+			-> a bunch of other SPI stuff
+		- xtrxll_set_param(XTRXLL_PARAM_FE_CTRL, XTRXLL_LMS7_GPWR_PIN | XTRXLL_LMS7_RESET_PIN | XTRXLL_LMS7_RXEN_PIN | XTRXLL_LMS7_TXEN_PIN)
+			-> U19 high
+			-> W17 high
+			-> W18 high
+			-> W19 high
+*/
 
 static int xtrx_init(void)
 {
@@ -353,16 +450,13 @@ static int xtrx_init(void)
 	printf("PMICs Initialization...\n");
 	printf("-----------------------\n");
 
-	printf("PMIC-LMS: Check ID ");
-	adr = 0x01;
-	i2c0_read(LP8758_I2C_ADDR, adr, &dat, 1, true);
-	if (dat != 0xe0) {
-		printf("KO, exiting.\n");
-		return 0;
-	} else {
-		printf("OK.\n");
+	// Check that the PMIC is alive
+	if (assert_pmic_alive() != 0) {
+		return -1;
 	}
 
+	// First, do a `lp8758_en(dev, 0, 1)`
+	// lp8758_set(dev, XTRX_I2C_PMIC_LMS, BUCK1_CTRL1, PMIC_CH_ENABLE);
 	printf("PMIC-LMS: Enable Buck1.\n");
 	adr = 0x04;
 	dat = 0x88;
@@ -373,16 +467,19 @@ static int xtrx_init(void)
 	dat = 0xfb;
 	i2c0_write(LP8758_I2C_ADDR, adr, &dat, 1);
 
+	// lp8758_set(dev, XTRX_I2C_PMIC_LMS, BUCK0_CTRL1, PMIC_CH_DISABLE);
 	printf("PMIC-LMS: Disable Buck0.\n");
 	adr = 0x02;
 	dat = 0xc8;
 	i2c0_write(LP8758_I2C_ADDR, adr, &dat, 1);
 
+	// lp8758_set(dev, XTRX_I2C_PMIC_LMS, BUCK2_CTRL1, PMIC_CH_DISABLE);
 	printf("PMIC-LMS: Disable Buck2.\n");
 	adr = 0x06;
 	dat = 0xc8;
 	i2c0_write(LP8758_I2C_ADDR, adr, &dat, 1);
 
+	// lp8758_set(dev, XTRX_I2C_PMIC_LMS, BUCK3_CTRL1, PMIC_CH_DISABLE);
 	printf("PMIC-LMS: Disable Buck3.\n");
 	adr = 0x08;
 	dat = 0xc8;
@@ -403,16 +500,11 @@ static int xtrx_init(void)
 	dat = 0x92;
 	i2c0_write(LP8758_I2C_ADDR, adr, &dat, 1);
 
-	busy_wait(1);
+	busy_wait(10);
 
-	printf("PMIC-FPGA: Check ID ");
-	adr = 0x1;
-	i2c1_read(LP8758_I2C_ADDR, adr, &dat, 1, true);
-	if (dat != 0xe0) {
-		printf("KO, exiting.\n");
-		return 0;
-	} else {
-		printf("OK.\n");
+	// Check that the PMIC is alive
+	if (assert_pmic_alive() != 0) {
+		return -1;
 	}
 
 	printf("PMIC-LMS: Enable Buck0.\n");
@@ -434,6 +526,9 @@ static int xtrx_init(void)
 	adr = 0x0c;
 	dat = 0xfb;
 	i2c1_write(LP8758_I2C_ADDR, adr, &dat, 1);
+
+	// Give the bucks some time to settle before bringing up the LMS7002m
+	busy_wait(100);
 
 	/* Get board revision */
 	printf("\n");
@@ -460,10 +555,10 @@ static int xtrx_init(void)
 	printf("---------------------------\n");
 	printf("LMS7002M Power-Down.\n");
 	lms7002m_control_write(LMS7002M_RESET | LMS7002M_POWER_DOWN);
-	busy_wait(1);
+	busy_wait(100);
 	printf("LMS7002M Reset.\n");
 	lms7002m_control_write(LMS7002M_RESET);
-	busy_wait(1);
+	busy_wait(10);
 	printf("LMS7002M TX/RX Enable.\n");
 	lms7002m_control_write(LMS7002M_TX_ENABLE | LMS7002M_RX_ENABLE);
 


### PR DESCRIPTION
We're comparing as best we can to an annotated powerup sequence as given
by the original XTRX firmware.