### PR TITLE
Add `sign_extend!()` to `libsigflow`

### DIFF
--- a/software/scripts/libsigflow.jl
+++ b/software/scripts/libsigflow.jl
@@ -443,3 +443,14 @@ function tripwire(in::Channel{Matrix{T}}, ctl::Base.Event;
     end)
     return out
 end
+
+
+function sign_extend!(x::AbstractArray{Complex{Int16}})
+    xi = reinterpret(Int16, x)
+    for idx in 1:length(xi)
+        if xi[idx] >= (1 << 11)
+            xi[idx] -= (1 << 12)
+        end
+    end
+    return x
+end

--- a/software/scripts/libsigflow_tests.jl
+++ b/software/scripts/libsigflow_tests.jl
@@ -208,3 +208,18 @@ end
         @test sum(PSD[(idx-1)*2+2:idx*2+1, idx]) > 5*sum(PSD[:, idx])/size(PSD,1)
     end
 end
+
+@testset "sign_extend" begin
+    sig = vcat(
+        [Complex{Int16}(idx,        4096 - idx) for idx in 1:2047],
+        [Complex{Int16}(4096 - idx, idx       ) for idx in 1:2047]
+    )
+    sign_extend!(sig)
+    for idx in 1:length(sig)
+        @test real(sig[idx]) == -imag(sig[idx])
+    end
+    # Test our two extremal points that do not have duals as above:
+    sig = [Complex{Int16}(0, 2048)]
+    sign_extend!(sig)
+    @test sig[1] == Complex{Int16}(0, -2048)
+end


### PR DESCRIPTION
When reading in the 12-bit samples from the XTRX, it's helpful to
sign-extend to the full 16 bits so we can deal with the data
efficiently.