### PR TITLE
Keep RF switches in sync with LMS antenna selection

### DIFF
--- a/software/Makefile.soapysdr
+++ b/software/Makefile.soapysdr
@@ -32,6 +32,7 @@ $(SOAPYSDR_XTRX_LIB): $(SOAPYSDR_LIB) $(LITEPCIE_LIB) LMS7002M-driver/.git/HEAD
 soapysdr-xtrx: $(SOAPYSDR_XTRX_LIB)
 clean-soapysdr-xtrx:
 	-$(MAKE) -C soapysdr-xtrx/build clean
+	$(RM) $(SOAPYSDR_XTRX_LIB)
 clean: clean-soapysdr-xtrx
 
 SOAPYSDR_JL_URL := https://github.com/JuliaTelecom/SoapySDR.jl.git


### PR DESCRIPTION
It was too messy to integrate this with LMS7002M-driver, since there's
no access to CSR values in that project.  I guess we'll just always use
this with Soapy, and never with anything else.