### PR TITLE
SoapySDR driver: support for multiple devices

### DIFF
--- a/software/soapysdr-xtrx/XTRXDevice.cpp
+++ b/software/soapysdr-xtrx/XTRXDevice.cpp
@@ -75,11 +75,14 @@ SoapyXTRX::SoapyXTRX(const SoapySDR::Kwargs &args)
     setvbuf(stdout, NULL, _IOLBF, 0);
 
     // open LitePCIe descriptor
-    //  TODO: configurable device number?
-    _fd = open("/dev/litepcie0", O_RDWR);
+    if (args.count("path") == 0) {
+        // if path is not present, then findXTRX had zero devices enumerated
+        throw std::runtime_error("No LitePCIe devices found!");
+    }
+    std::string path = args.at("path");
+    _fd = open(path.c_str(), O_RDWR);
     if (_fd < 0)
-        throw std::runtime_error(
-            "SoapyXTRX(): failed to open /dev/litepcie0");
+        throw std::runtime_error("SoapyXTRX(): failed to open " + path);
 
     // reset the LMS7002M
     litepcie_writel(_fd, CSR_LMS7002M_CONTROL_ADDR,
@@ -1055,9 +1058,27 @@ void SoapyXTRX::writeSetting(const std::string &key, const std::string &value) {
  **********************************************************************/
 
 std::vector<SoapySDR::Kwargs> findXTRX(const SoapySDR::Kwargs &args) {
-    // always discovery "args" -- the sdr is the board itself
     std::vector<SoapySDR::Kwargs> discovered;
-    discovered.push_back(args);
+
+    // TODO: select by serial number, or something unique to each device
+    //       (like the FPGA's DNA; but that currently reads-out incorrectly)
+
+    if (args.count("path") != 0) {
+        // respect user choice
+        discovered.push_back(args);
+    } else {
+        // find all LitePCIe devices
+        // TODO: check whether these are XTRX devices
+        for (int i = 0; i < 10; i++) {
+            std::string path = "/dev/litepcie" + std::to_string(i);
+            if (access(path.c_str(), F_OK) != 0)
+                continue;
+            SoapySDR::Kwargs dev(args);
+            dev["path"] = path;
+            discovered.push_back(dev);
+        }
+    }
+
     return discovered;
 }
 


### PR DESCRIPTION
With this, the XTRX device is per-path, and should discover automatically:

```
$ SoapySDRUtil --find
######################################################
##     Soapy SDR -- the SDR abstraction library     ##
######################################################

Found device 0
  driver = XTRX
  path = /dev/litepcie0
```

For serial-based identification, I had a look at the FPGA's DNA, but the returned value seems fishy:

```patch
diff --git a/fairwaves_xtrx.py b/fairwaves_xtrx.py
index 06c908a..a7efec7 100755
--- a/fairwaves_xtrx.py
+++ b/fairwaves_xtrx.py
@@ -27,6 +27,7 @@ from litex.soc.cores.gpio import GPIOOut
 from litex.soc.cores.spi_flash import S7SPIFlash
 from litex.soc.cores.bitbang import I2CMaster
 from litex.soc.cores.xadc import XADC
+from litex.soc.cores.dna  import DNA

 from litepcie.phy.s7pciephy import S7PCIEPHY

@@ -134,6 +135,10 @@ class BaseSoC(SoCCore):
         # XADC -------------------------------------------------------------------------------------
         self.submodules.xadc = XADC()

+        # DNA --------------------------------------------------------------------------------------
+        self.submodules.dna = DNA()
+        self.dna.add_timing_constraints(platform, sys_clk_freq, self.crg.cd_sys.clk)
+
         # PCIe -------------------------------------------------------------------------------------
         self.submodules.pcie_phy = S7PCIEPHY(platform, platform.request(f"pcie_x2"),
             data_width = 64,
```
```
$ ./litepcie_util info
FPGA identification: LiteX SoC on Fairwaves XTRX 2022-08-29 12:25:45
FPGA dna: 0x01c01c1c1df01f1f
FPGA temperature: 58.3 °C
FPGA vccint: 0.95 V
FPGA vccaux: 1.77 V
FPGA vccbram: 0.95 V
```

Also, the internet tells me we should use the 64-bit FUSE_DNA instead of the 57-bit DNA_PORT, but I don't know how to read that from Verilog (i.e., just changing DNA_PORT to FUSE_DNA in LiteX' generators doesn't work).

Filed an issue for this, https://github.com/enjoy-digital/litex/issues/1411, but it's not critical.