### PR TITLE
Fixes and improvements towards support for high-level API

### DIFF
--- a/software/soapysdr-xtrx/Streaming.cpp
+++ b/software/soapysdr-xtrx/Streaming.cpp
@@ -8,16 +8,6 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 //
 
-// TODO
-//
-// - we're not properly setting the channels here, see ch2LMS/setAntenna/etc
-//   in the EVB7 driver (https://github.com/myriadrf/LMS7002M-driver/tree/master/evb7)
-//
-// - we're also completely ignoring formats
-//
-// - implement the user-friendlier non-zero copy API on top of this? see e.g.
-//   https://github.com/pothosware/SoapyHackRF/blob/master/HackRF_Streaming.cpp
-
 #include "XTRXDevice.hpp"
 
 #include <chrono>
@@ -135,8 +125,6 @@ int SoapyXTRX::activateStream(SoapySDR::Stream *stream, const int /*flags*/,
         litepcie_dma_reader(_fd, 1, &_tx_stream.hw_count, &_tx_stream.sw_count);
         _tx_stream.user_count = 0;
     }
-
-    // TODO: set-up the LMS7002M
 
     return 0;
 }
@@ -393,14 +381,12 @@ int SoapyXTRX::readStream(
     {
         return SOAPY_SDR_NOT_SUPPORTED;
     }
-    /* this is the user's buffer for channel 0 */
     size_t returnedElems = std::min(numElems, this->getStreamMTU(stream));
 
     size_t samp_avail = 0;
 
     if (_rx_stream.remainderHandle >= 0)
     {
-
         const size_t n = std::min(_rx_stream.remainderSamps, returnedElems);
 
         if (n < returnedElems)

--- a/software/soapysdr-xtrx/Streaming.cpp
+++ b/software/soapysdr-xtrx/Streaming.cpp
@@ -85,7 +85,7 @@ SoapySDR::Stream *SoapyXTRX::setupStream(const int direction,
 
         _tx_stream.opened = true;
 
-        _rx_stream.format = format;
+        _tx_stream.format = format;
 
         return TX_STREAM;
     } else {
@@ -356,7 +356,7 @@ void readbuf(int8_t *src, void *dst, uint32_t len, std::string format, size_t of
     }
     else
     {
-        SoapySDR_log(SOAPY_SDR_ERROR, "read format not support");
+        SoapySDR_logf(SOAPY_SDR_ERROR, "Unsupported read format: %s", format.c_str());
     }
 }
 
@@ -373,7 +373,7 @@ void writebuf(const void *src, int8_t *dst, uint32_t len, std::string format, si
     }
     else
     {
-        SoapySDR_log(SOAPY_SDR_ERROR, "write format not support");
+        SoapySDR_logf(SOAPY_SDR_ERROR, "Unsupported write format: %s", format.c_str());
     }
 }
 

--- a/software/soapysdr-xtrx/Streaming.cpp
+++ b/software/soapysdr-xtrx/Streaming.cpp
@@ -399,13 +399,11 @@ int SoapyXTRX::readStream(
         {
             deinterleave(_rx_stream.remainderBuff + _rx_stream.remainderOffset * BYTES_PER_SAMPLE, buffs[i], n/2, _rx_stream.format, _rx_stream.channels[i]);
         }
-
-        _rx_stream.remainderOffset += n;
         _rx_stream.remainderSamps -= n;
+        _rx_stream.remainderOffset += n;
 
         if (_rx_stream.remainderSamps == 0)
         {
-
             this->releaseReadBuffer(stream, _rx_stream.remainderHandle);
             _rx_stream.remainderHandle = -1;
             _rx_stream.remainderOffset = 0;
@@ -432,7 +430,11 @@ int SoapyXTRX::readStream(
 
     const size_t n = std::min((returnedElems - samp_avail), _rx_stream.remainderSamps);
 
-    deinterleave(_rx_stream.remainderBuff, buffs[0], n, _rx_stream.format, samp_avail);
+    // Read out channels
+    for (size_t i = 0; i < _rx_stream.channels.size(); i++)
+    {
+        deinterleave(_rx_stream.remainderBuff, buffs[i], n, _rx_stream.format, samp_avail + _rx_stream.channels[i]);
+    }
     _rx_stream.remainderSamps -= n;
     _rx_stream.remainderOffset += n;
 
@@ -443,7 +445,7 @@ int SoapyXTRX::readStream(
         _rx_stream.remainderOffset = 0;
     }
 
-    return (returnedElems);
+    return returnedElems;
 }
 
 int SoapyXTRX::writeStream(
@@ -478,7 +480,6 @@ int SoapyXTRX::writeStream(
         {
             interleave(buffs[i], _tx_stream.remainderBuff + _tx_stream.remainderOffset * BYTES_PER_SAMPLE, n/2, _tx_stream.format, _tx_stream.channels[i]);
         }
-
         _tx_stream.remainderSamps -= n;
         _tx_stream.remainderOffset += n;
 
@@ -510,7 +511,11 @@ int SoapyXTRX::writeStream(
 
     const size_t n = std::min((returnedElems - samp_avail), _tx_stream.remainderSamps);
 
-    interleave(buffs[0], _tx_stream.remainderBuff, n, _tx_stream.format, samp_avail);
+    // Write out channels
+    for (size_t i = 0; i < _tx_stream.channels.size(); i++)
+    {
+        interleave(buffs[i], _tx_stream.remainderBuff, n, _tx_stream.format, samp_avail + _tx_stream.channels[i]);
+    }
     _tx_stream.remainderSamps -= n;
     _tx_stream.remainderOffset += n;
 

--- a/software/soapysdr-xtrx/XTRXDevice.hpp
+++ b/software/soapysdr-xtrx/XTRXDevice.hpp
@@ -302,6 +302,7 @@ class DLL_EXPORT SoapyXTRX : public SoapySDR::Device {
         size_t remainderOffset;
         int8_t* remainderBuff;
         std::string format;
+        std::vector<size_t> channels;
     };
 
     struct RXStream: Stream {

--- a/software/soapysdr-xtrx/XTRXDevice.hpp
+++ b/software/soapysdr-xtrx/XTRXDevice.hpp
@@ -289,7 +289,8 @@ class DLL_EXPORT SoapyXTRX : public SoapySDR::Device {
     void *_dma_buf;
 
     struct Stream {
-        Stream() : opened(false) {}
+        Stream() : opened(false), remainderHandle(-1), remainderSamps(0),
+                   remainderOffset(0), remainderBuff(nullptr) {}
 
         bool opened;
         void *buf;


### PR DESCRIPTION
This reworks the test_pattern script to use the high level API. This (unsurprisingly) fails, as the interlacing code needs to be finished. It was copied from HackRF, but it was only robustly testable now in this script. I modified the assertions assuming the following:

The basic DMA format is:
```
[(Ia_1, Ib_1), (Qa_1, Qb_1), (Ia_2, Ib_2) ...] 
```
So both the I values for Channel A and B are sent together, followed by the Q. 

We want to transform this into one array for each channel of Complex Int16. Ideally we also sign extend and such so the simplest API in Soapy may be used without any device specific hacks.
