### PR TITLE
Report to the user which device is being opened

### DIFF
--- a/software/scripts/acquire_iq.jl
+++ b/software/scripts/acquire_iq.jl
@@ -51,8 +51,14 @@ end
 function do_txrx(mode::Symbol;
                  register_sets::Vector{<:Pair} = Pair[],
                  dump_inis::Bool = false)
-    # open the first device
-    Device(first(Devices())) do dev
+    # If we're running on pathfinder, pick a specific device
+    device_kwargs = Dict{Symbol,Any}()
+    if chomp(String(read(`hostname`))) == "pathfinder"
+        device_kwargs[:driver] = "XTRX"
+        device_kwargs[:serial] = "121c444ea8c85c"
+    end
+
+    Device(first(Devices(;device_kwargs...))) do dev
         # Get some useful parameters
         format = dev.rx[1].native_stream_format
         fullscale = dev.tx[1].fullscale

--- a/software/soapysdr-xtrx/XTRXDevice.cpp
+++ b/software/soapysdr-xtrx/XTRXDevice.cpp
@@ -40,6 +40,9 @@ void customLogHandler(const LMS7_log_level_t level, const char *message) {
     }
 }
 
+// Forward declaration for usage in constructor.
+std::string getXTRXSerial(int fd);
+
 
 /***********************************************************************
  * Constructor
@@ -82,6 +85,7 @@ SoapyXTRX::SoapyXTRX(const SoapySDR::Kwargs &args)
     if (_fd < 0)
         throw std::runtime_error("SoapyXTRX(): failed to open " + path);
 
+    SoapySDR::logf(SOAPY_SDR_INFO, "Opened devnode %s, serial %s", path.c_str(), getXTRXSerial(_fd).c_str());
     // reset the LMS7002M
     litepcie_writel(_fd, CSR_LMS7002M_CONTROL_ADDR,
         1 * (1 << CSR_LMS7002M_CONTROL_RESET_OFFSET)


### PR DESCRIPTION
Also, in `acquire_iq`, if we're running on `pathfinder`, select the XTRX
that's in the carrier board, not one of the XYNC devices.