### PR TITLE
Test full MIMO acquire_iq.jl

### DIFF
--- a/software/scripts/acquire_iq.jl
+++ b/software/scripts/acquire_iq.jl
@@ -103,7 +103,7 @@ function do_txrx(mode::Symbol;
             if mode != :trf_loopback
                 cr.antenna = :LNAL
             else
-                cr.antenna = Symbol("LB$(c_idx)")
+                cr.antenna = :LB1
             end
         end
 
@@ -202,6 +202,10 @@ function do_txrx(mode::Symbol;
         data_tx[1, :] .= format.(
             round.(sin.(2π.*t.*rate).*(fullscale/2).*0.95.*DSP.hanning(samples)),
             round.(cos.(2π.*t.*rate).*(fullscale/2).*0.95.*DSP.hanning(samples)),
+        )
+        data_tx[2, :] .= format.(
+            round.(sin.(8π.*t.*rate).*(fullscale/2).*0.95.*DSP.hanning(samples)),
+            round.(cos.(8π.*t.*rate).*(fullscale/2).*0.95.*DSP.hanning(samples)),
         )
 
         # We're going to push values onto this list,


### PR DESCRIPTION
We were setting the wrong loopback when doing TRF loopback; the number
doesn't indicate which TX channel to read from, it indicates which TX
_band_ to read from.  In our case, we're always transmitting from band
1, so select accordingly.