### PR TITLE
Add libsigflow blocks for XTRX and streaming to disk

### DIFF
--- a/software/scripts/libsigflow.jl
+++ b/software/scripts/libsigflow.jl
@@ -236,6 +236,12 @@ function stream_data(paths::Vector{<:AbstractString}, in::Channel{Matrix{T}}) wh
     end)
 end
 
+"""
+    stream_data(paths::Vector{<:AbstractString}, T::DataType; chunk_size)
+
+Read in a set of files as a coherent chunk of channels.  Use `chunk_size`
+to set the initial stream buffer chunk size (defaults to a 4K page on disk)
+"""
 function stream_data(paths::Vector{<:AbstractString}, T::DataType;
                      chunk_size::Int = div(4096, sizeof(T)))
     fds = [open(path, read=true) for path in paths]


### PR DESCRIPTION
These new libsigflow blocks should allow transparent usage of XTRX
hardware, even without the high-level streaming API.  It also allows for
streaming to/from files in a convenient manner.

This PR also changes `acquire_iq.jl` to use libsigflow blocks.  Theoretically, this now allows for the same script to be run on the XTRX and the LimeSDR.