### PR TITLE
Extend TX test pattern to be a 24-bit counter

### DIFF
--- a/gateware/lms7002m.py
+++ b/gateware/lms7002m.py
@@ -103,25 +103,22 @@ class TXPatternGenerator(Module, AutoCSR):
         # ----------
 
         # Counter.
-        count0 = Signal(12)
-        count1 = Signal(12)
+        count = Signal(24)
         self.sync.rfic += [
             # Reset Count when disabled.
             If(~enable,
-                count0.eq(0),
-                count1.eq(0),
+                count.eq(0),
             # Increment Count when enabled.
             ).Else(
-                count0.eq(count0 + 1),
-                count1.eq(count1 + 2),
+                count.eq(count + 1),
             )
         ]
 
         # Data-Path.
         # ----------
         self.sync.rfic += [
-            self.source.data[ 0:16].eq(count0),
-            self.source.data[16:32].eq(count1),
+            self.source.data[ 0:16].eq(count[ 0:12]),
+            self.source.data[16:32].eq(count[12:24]),
         ]
 
 

--- a/gateware/lms7002m.py
+++ b/gateware/lms7002m.py
@@ -145,12 +145,10 @@ class RXPatternChecker(Module, AutoCSR):
         # Checker/Data-Path.
         # -------------------
         count_error = Signal()
-        count0      = Signal(12)
-        count1      = Signal(12)
-        self.sync.rfic += count0.eq(self.sink.data[0:])
-        self.sync.rfic += count1.eq(self.sink.data[16:])
-        self.comb += If(self.sink.data[ 0:12] != (count0 + 1), count_error.eq(1))
-        self.comb += If(self.sink.data[16:28] != (count1 + 2), count_error.eq(1))
+        count       = Signal(24)
+        self.sync.rfic += count[ 0:12].eq(self.sink.data[0:16])
+        self.sync.rfic += count[12:24].eq(self.sink.data[16:32])
+        self.comb += If(Cat(self.sink.data[0:12], self.sink.data[16:28]) != (count + 1), count_error.eq(1))
 
         # Errors.
         # -------

--- a/software/scripts/libsigflow.jl
+++ b/software/scripts/libsigflow.jl
@@ -30,6 +30,22 @@ function spawn_channel_thread(f::Function; T::DataType = ComplexF32, buffers_in_
     return out
 end
 
+
+
+"""
+    membuffer(in, max_size = 16)
+
+Provide some buffering for realtime applications.
+"""
+function membuffer(in::Channel{Matrix{T}}, max_size::Int = 16) where {T}
+    spawn_channel_thread(;T, buffers_in_flight=max_size) do out
+        consume_channel(in) do buff
+            put!(out, buff)
+        end
+    end
+end
+
+
 """
     generate_stream(gen_buff!::Function, buff_size, num_channels)
 

--- a/software/scripts/libsigflow.jl
+++ b/software/scripts/libsigflow.jl
@@ -209,8 +209,7 @@ function stream_data(s_rx::SoapySDR.Stream{T}, end_condition::Union{Integer,Base
             end
         end
 
-        if !soapy_read!(s_rx, buff; auto_sign_extend)
-            return false
+        while !soapy_read!(s_rx, buff; auto_sign_extend)
         end
 
         buff_idx += 1

--- a/software/scripts/test_pattern.jl
+++ b/software/scripts/test_pattern.jl
@@ -5,12 +5,11 @@
 using SoapySDR
 using Test
 using CUDA
+device!(0)  # SoapySDR needs CUDA to be initialized
 
 #SoapySDR.register_log_handler()
 
-
 function dma_test(dev_args;use_gpu=false, lfsr_mode=false)
-
     # GPU: set the DMA target
     dma_mode = use_gpu ? "GPU" : "CPU"
     dev_args["device"] = dma_mode
@@ -57,7 +56,7 @@ function dma_test(dev_args;use_gpu=false, lfsr_mode=false)
 
         # acquire buffers using the low-level API
         buffs = Ptr{UInt32}[C_NULL]
-        bytes = mtu*4
+        bytes = mtu*num_channels*4
         total_bytes = 0
 
         prior_pointer = Ptr{UInt32}(0)
@@ -73,12 +72,17 @@ function dma_test(dev_args;use_gpu=false, lfsr_mode=false)
 
         @info "Receiving data using $dma_mode with $test_mode..."
         SoapySDR.activate!(stream) do
-            time = @elapsed for i in 1:600
+            time = @elapsed for i in 1:50000
                 err, handle, flags, timeNs = SoapySDR.SoapySDRDevice_acquireReadBuffer(dev, stream, buffs)
                 if err == SoapySDR.SOAPY_SDR_OVERFLOW
                     overflow_events += 1
-                elseif err == SoapySDR.SOAPY_SDR_TIMEOUT
+                    initialized_count = false
+
+                    # this buffer is invalid
                     SoapySDR.SoapySDRDevice_releaseReadBuffer(dev, stream, handle)
+                    total_bytes += bytes
+                    continue
+                elseif err == SoapySDR.SOAPY_SDR_TIMEOUT
                     continue
                 end
 
@@ -91,7 +95,7 @@ function dma_test(dev_args;use_gpu=false, lfsr_mode=false)
                     #
                     # we also shouldn't wait for the GPU to finish processing the data,
                     # but that requires more careful design that's out of scope here.
-            
+
                     arr = unsafe_wrap(CuArray{Complex{Int16}, 1}, reinterpret(CuPtr{Complex{Int16}}, buffs[1]), Int(mtu*num_channels))
                     if !initialized_count
                         #setup arrays for comparison
@@ -102,8 +106,13 @@ function dma_test(dev_args;use_gpu=false, lfsr_mode=false)
                     # copy the array over to the CPU for validation
                     copyto!(comp, arr)
 
+                    # check the data
+                    # XXX: this loop does not stay within the 60us time budget
                     for j in eachindex(comp)
-                        @assert comp[j] == Complex{Int16}(counter & 0xfff, (counter >> 12) & 0xfff)
+                        z = Complex{Int16}(counter & 0xfff, (counter >> 12) & 0xfff)
+                        if comp[j] != z
+                            @warn("Error", received=comp[j], expected=z)
+                        end
                         counter = (counter + 1) & 0xffffff
                     end
 
@@ -114,35 +123,40 @@ function dma_test(dev_args;use_gpu=false, lfsr_mode=false)
 
                     if lfsr_mode
                         buf = unsafe_wrap(Array{UInt16}, reinterpret(Ptr{UInt16}, buffs[1]), Int(mtu*num_channels*2))
+
                         # LFSR data check
                         for j in 1:2:length(buf)-1
-                            @assert buf[j] == ((~buf[j+1]) & 0x0fff)
+                            z = (~buf[j+1]) & 0x0fff
+                            if buf[j] != z
+                                @warn("Error", received=buf[j], expected=z)
+                            end
                         end
                     else
                         buf = unsafe_wrap(Array{Complex{Int16}}, reinterpret(Ptr{Complex{Int16}}, buffs[1]), Int(mtu*num_channels))
+
                         # sync the counter on start
                         if !initialized_count
                             counter = Int32(real(buf[1])) & 0xfff | ((Int32(imag(buf[1])) & 0xfff) << 12)
                             initialized_count = true
                         end
 
+                        # check the data
+                        # XXX: this loop does not stay within the 60us time budget
                         for j in eachindex(buf)
                             z = Complex{Int16}(counter & 0xfff, (counter >> 12) & 0xfff)
                             if buf[j] != z
                                 @warn("Error", received=buf[j], expected=z)
                             end
-                            @assert buf[j] == z
                             counter = (counter + 1) & 0xffffff
                         end
                     end
 
-                    buf_pointer = reinterpret(Ptr{UInt32}, buffs[1])
-
                     # make sure we aren't recycling the same buffer
+                    # XXX: this can fail when overflowing a lot
+                    buf_pointer = reinterpret(Ptr{UInt32}, buffs[1])
                     if i != 1
                         @assert prior_pointer != buf_pointer
                     end
-
                     prior_pointer = buf_pointer
                 end
 
@@ -151,28 +165,22 @@ function dma_test(dev_args;use_gpu=false, lfsr_mode=false)
                 total_bytes += bytes
             end
             @info "Data rate: $(Base.format_bytes(total_bytes / time))/s"
-            @info "Overflow Events: $overflow_events"
+            @info "Overflow events: $overflow_events"
 
         end
     end
 end
 
-using CUDA
-# GPU: initialize the device# GPU: initialize the device
-device!(0)
-CuArray(UInt32[1]) .= 1
-# XXX: actually creating an array to initialize CUDA won't be required anymore
-#      in the next version of CUDA.jl, but it helps to ensure code is compiled
-
-using Base.Threads
-
-for dev_args in Devices(driver="XTRX")
-    try
-        dma_test(dev_args;use_gpu=false, lfsr_mode=true)
-        dma_test(dev_args;use_gpu=false, lfsr_mode=false)
-        dma_test(dev_args;use_gpu=true, lfsr_mode=false)
-    catch e
-        @error("failed on $(dev_args["path"]), serial: $(dev_args["serial"])")
-        @error(e)
+function main()
+    for dev_args in Devices(driver="XTRX")
+        try
+            dma_test(dev_args; use_gpu=false, lfsr_mode=true)
+            dma_test(dev_args; use_gpu=false, lfsr_mode=false)
+            dma_test(dev_args; use_gpu=true,  lfsr_mode=false)
+        catch e
+            @error "Test failed" path=dev_args["path"] serial=dev_args["serial"] exception=(e, catch_backtrace())
+        end
     end
 end
+
+isinteractive() || main()

--- a/software/scripts/test_pattern.jl
+++ b/software/scripts/test_pattern.jl
@@ -77,10 +77,6 @@ function dma_test(dev_args;use_gpu=false, lfsr_mode=false)
                 if err == SoapySDR.SOAPY_SDR_OVERFLOW
                     overflow_events += 1
                     initialized_count = false
-
-                    # this buffer is invalid
-                    SoapySDR.SoapySDRDevice_releaseReadBuffer(dev, stream, handle)
-                    total_bytes += bytes
                     continue
                 elseif err == SoapySDR.SOAPY_SDR_TIMEOUT
                     continue

--- a/software/scripts/test_pattern_multithreaded.jl
+++ b/software/scripts/test_pattern_multithreaded.jl
@@ -75,7 +75,7 @@ function dma_test(dev_args)
                     # We may fail a few times while compiling at first, because we'll drop buffers.
                     # but eventually, we should be able to keep up with the data stream, as long as
                     # it's low enough.
-                    @warn("Error", pbuff[j], comp, buffs_processed)
+                    @warn("Error", j, pbuff[j], comp, buffs_processed, _num_overflows[])
                     errors += 1
                     initialized_count = false
                     break

--- a/software/scripts/test_pattern_multithreaded.jl
+++ b/software/scripts/test_pattern_multithreaded.jl
@@ -1,0 +1,78 @@
+# configure the XTRX to generate a data pattern in the FPGA,
+# and try receiving that pattern using the LMS7002M RF IC.
+# the pattern is just a counter, so the array should contain increasing numbers.
+
+using SoapySDR, Unitful, Test
+
+include("./libsigflow.jl")
+include("./xtrx_debugging.jl")
+
+if Threads.nthreads() < 2
+    error("This script must be run with multiple threads!")
+end
+
+
+#SoapySDR.register_log_handler()
+
+# Disable GC for this test to minimize underflows
+GC.enable(false)
+
+function dma_test(dev_args)
+    Device(dev_args) do dev
+        # Setup transmission/recieve parameters
+        set_cgen_freq(dev, 64u"MHz")
+        sample_rate = 2u"MHz"
+        for (c_idx, cr) in enumerate(dev.rx)
+            cr.sample_rate = sample_rate
+        end
+        for ct in dev.tx
+            ct.sample_rate = sample_rate
+        end
+
+        SoapySDR.SoapySDRDevice_writeSetting(dev, "LOOPBACK_ENABLE_LFSR", "FALSE")
+        SoapySDR.SoapySDRDevice_writeSetting(dev, "RESET_RX_FIFO", "")
+        SoapySDR.SoapySDRDevice_writeSetting(dev, "FPGA_TX_PATTERN", "1")
+        SoapySDR.SoapySDRDevice_writeSetting(dev, "LOOPBACK_ENABLE", "TRUE")
+
+        # open MIMO RX stream
+        stream = SoapySDR.Stream(dev.rx[1].native_stream_format, dev.rx)
+
+        mtu = SoapySDR.SoapySDRDevice_getStreamMTU(dev, stream)
+        wr_nbufs = SoapySDR.SoapySDRDevice_getNumDirectAccessBuffers(dev, stream)
+        @info "Number of DMA buffers: $wr_nbufs"
+        @info "MTU: $mtu"
+
+        total_bytes = 0
+        initialized_count = false
+
+        c = stream_data(stream, mtu*wr_nbufs*2000; auto_sign_extend=false, leadin_buffers=0)
+
+        # Log out information about data rate and such
+        c = log_stream_xfer(c)
+
+        counter = 0
+        consume_channel(c) do buff
+            # Pick up wherever we are in the sequence
+            if !initialized_count
+                counter = (real(buff[1]) & 0xfff) + ((imag(buff[1]) & 0xfff) << 12)
+                initialized_count = true
+            end
+
+            # libsigflow permutes our data into a standardized ordering
+            # let's un-permute to get back to the native ordering, which
+            # is better for this test.
+            pbuff = permutedims(buff)
+            for j in eachindex(pbuff)
+                comp = Complex{Int16}(counter & 0xfff, (counter >> 12) & 0xfff)
+                if pbuff[j] != comp
+                    @error("fail", j, pbuff[j], comp, total_bytes)
+                end
+                @assert pbuff[j] == comp
+                counter = (counter + 1) & 0xffffff
+            end
+            total_bytes += sizeof(buff)
+        end
+    end
+end
+
+dma_test(first(Devices(driver="XTRX")))

--- a/software/scripts/test_pattern_multithreaded.jl
+++ b/software/scripts/test_pattern_multithreaded.jl
@@ -20,8 +20,9 @@ GC.enable(false)
 function dma_test(dev_args)
     Device(dev_args) do dev
         # Setup transmission/recieve parameters
-        set_cgen_freq(dev, 32u"MHz")
-        sample_rate = 2u"MHz"
+        # Try increasing `sample_rate`
+        sample_rate = 1u"MHz"
+        set_cgen_freq(dev, 16*sample_rate)
         for cr in dev.rx
             cr.sample_rate = sample_rate
         end

--- a/software/scripts/xtrx_debugging.jl
+++ b/software/scripts/xtrx_debugging.jl
@@ -1,3 +1,5 @@
+using Unitful
+
 # Debugging register poking API.  This is very unportable
 const SoapyXTRXModules =
     get(ENV, "SOAPY_SDR_PLUGIN_PATH",
@@ -15,6 +17,7 @@ function set_cgen_freq(dev::Device, clk_rate::Float64)
     ccall((:_ZN9SoapyXTRX18setMasterClockRateEd, libSoapyXTRX), Cvoid, (Ptr{Cvoid}, Cdouble), dev.ptr, clk_rate)
     return nothing
 end
+set_cgen_freq(dev::Device, clk_freq::Unitful.Frequency) = set_cgen_freq(dev, Float64(upreferred(clk_freq).val))
 function get_cgen_freq(dev::Device)
     return ccall((:_ZNK9SoapyXTRX18getMasterClockRateEv, libSoapyXTRX), Cdouble, (Ptr{Cvoid},), dev.ptr)
 end

--- a/software/soapysdr-xtrx/Streaming.cpp
+++ b/software/soapysdr-xtrx/Streaming.cpp
@@ -247,25 +247,35 @@ int SoapyXTRX::acquireReadBuffer(SoapySDR::Stream *stream, size_t &handle,
         assert(buffers_available > 0);
     }
 
-    // get the buffer
-    int buf_offset = _rx_stream.user_count % _dma_mmap_info.dma_rx_buf_count;
-    getDirectAccessBufferAddrs(stream, buf_offset, (void **)buffs);
-
-    // update the DMA counters
-    handle = _rx_stream.user_count;
-    _rx_stream.user_count++;
-
     // detect overflows of the underlying circular buffer
     if ((_rx_stream.hw_count - _rx_stream.sw_count) >
         ((int64_t)_dma_mmap_info.dma_rx_buf_count / 2)) {
+        // drain all buffers to get out of the overflow quicker
+        struct litepcie_ioctl_mmap_dma_update mmap_dma_update;
+        mmap_dma_update.sw_count = _rx_stream.hw_count;
+        checked_ioctl(_fd, LITEPCIE_IOCTL_MMAP_DMA_WRITER_UPDATE, &mmap_dma_update);
+        _rx_stream.user_count = _rx_stream.hw_count;
+        _rx_stream.sw_count = _rx_stream.hw_count;
+        handle = -1;
+
         flags |= SOAPY_SDR_END_ABRUPT;
         return SOAPY_SDR_OVERFLOW;
     } else {
+        // get the buffer
+        int buf_offset = _rx_stream.user_count % _dma_mmap_info.dma_rx_buf_count;
+        getDirectAccessBufferAddrs(stream, buf_offset, (void **)buffs);
+
+        // update the DMA counters
+        handle = _rx_stream.user_count;
+        _rx_stream.user_count++;
+
         return getStreamMTU(stream);
     }
 }
 
 void SoapyXTRX::releaseReadBuffer(SoapySDR::Stream */*stream*/, size_t handle) {
+    assert(handle != (size_t)-1 && "Attempt to release an invalid buffer (e.g., from an overflow)");
+
     // update the DMA counters
     struct litepcie_ioctl_mmap_dma_update mmap_dma_update;
     mmap_dma_update.sw_count = handle + 1;

--- a/software/soapysdr-xtrx/Streaming.cpp
+++ b/software/soapysdr-xtrx/Streaming.cpp
@@ -256,10 +256,8 @@ int SoapyXTRX::acquireReadBuffer(SoapySDR::Stream *stream, size_t &handle,
     _rx_stream.user_count++;
 
     // detect overflows of the underlying circular buffer
-    // NOTE: the kernel driver is more aggressive here and
-    //       treats a difference of half the count as an overflow
     if ((_rx_stream.hw_count - _rx_stream.sw_count) >
-        ((int64_t)_dma_mmap_info.dma_rx_buf_count)) {
+        ((int64_t)_dma_mmap_info.dma_rx_buf_count / 2)) {
         flags |= SOAPY_SDR_END_ABRUPT;
         return SOAPY_SDR_OVERFLOW;
     } else {

--- a/software/soapysdr-xtrx/Streaming.cpp
+++ b/software/soapysdr-xtrx/Streaming.cpp
@@ -242,8 +242,7 @@ int SoapyXTRX::acquireReadBuffer(SoapySDR::Stream *stream, size_t &handle,
         }
 
         // get new DMA counters
-        litepcie_dma_writer(_fd, 1, &_rx_stream.hw_count,
-                            &_rx_stream.user_count);
+        litepcie_dma_writer(_fd, 1, &_rx_stream.hw_count, &_rx_stream.sw_count);
         buffers_available = _rx_stream.hw_count - _rx_stream.user_count;
         assert(buffers_available > 0);
     }
@@ -302,8 +301,7 @@ int SoapyXTRX::acquireWriteBuffer(SoapySDR::Stream *stream, size_t &handle,
             return SOAPY_SDR_TIMEOUT;
 
         // get new DMA counters
-        litepcie_dma_reader(_fd, 1, &_tx_stream.hw_count,
-                            &_tx_stream.user_count);
+        litepcie_dma_reader(_fd, 1, &_tx_stream.hw_count, &_tx_stream.sw_count);
         buffers_pending = _tx_stream.user_count - _tx_stream.hw_count;
         assert(buffers_pending < ((int64_t)_dma_mmap_info.dma_tx_buf_count));
     }


### PR DESCRIPTION
This should catch buffer reordering/reuse problems, which may not
currently be caught, since the test pattern fits neatly into two
buffers, causing every other buffer to be identical.