### PR TITLE
Continue work on high-level API

### DIFF
--- a/software/scripts/test_pattern_highlevel.jl
+++ b/software/scripts/test_pattern_highlevel.jl
@@ -1,0 +1,91 @@
+# configure the XTRX to generate a data pattern in the FPGA,
+# and try receiving that pattern using the LMS7002M RF IC.
+# the pattern is just a counter, so the array should contain increasing numbers.
+
+using SoapySDR
+using Test
+using Unitful
+
+#SoapySDR.register_log_handler()
+
+function dma_test(dev_args;lfsr_mode=false, show_mismatch=false)
+
+    Device(dev_args) do dev
+        # get the RX channel
+        chans = dev.rx
+
+        if lfsr_mode
+            SoapySDR.SoapySDRDevice_writeSetting(dev, "RESET_RX_FIFO", "")
+            SoapySDR.SoapySDRDevice_writeSetting(dev, "LOOPBACK_ENABLE_LFSR", "TRUE")
+            SoapySDR.SoapySDRDevice_writeSetting(dev, "RESET_RX_FIFO", "")
+        else
+            SoapySDR.SoapySDRDevice_writeSetting(dev, "LOOPBACK_ENABLE_LFSR", "FALSE")
+            SoapySDR.SoapySDRDevice_writeSetting(dev, "RESET_RX_FIFO", "")
+            SoapySDR.SoapySDRDevice_writeSetting(dev, "FPGA_TX_PATTERN", "1")
+            SoapySDR.SoapySDRDevice_writeSetting(dev, "LOOPBACK_ENABLE", "TRUE")
+        end
+
+        # open RX stream
+        stream = SoapySDR.Stream(chans)
+
+        mtu = stream.mtu
+        num_channels = Int(length(dev.rx))
+
+        # we want to go through the ring buffer a few times.        
+        rd_nbufs = SoapySDR.SoapySDRDevice_getNumDirectAccessBuffers(dev, stream)
+        nbufs = 3 #rd_nbufs*3
+
+        # pre allocate memory to copy the data into.
+        bufs = ntuple(_->Vector{chans[1].native_stream_format}(undef, mtu*nbufs), num_channels)
+
+        total_bytes = nbufs*mtu*sizeof(chans[1].native_stream_format)*num_channels
+
+        @info "MTU: $mtu, Buffer Count: $(rd_nbufs)"
+
+        @info "Receiving data..."
+        time_rd = @elapsed SoapySDR.activate!(stream) do
+            read!(stream, bufs)
+        end
+
+        @info "Data read rate: $(Base.format_bytes(total_bytes / time_rd))/s, Total Bytes: $(Base.format_bytes(total_bytes))"
+
+        error_count = 0
+
+        time_validation = @elapsed begin
+
+            counter = Int32(real(bufs[1][1])) & 0xfff | ((Int32(imag(bufs[1][1])) & 0xfff) << 12)
+
+            for j in 1:length(bufs[1])
+                # the counter is 24 bits.
+                z1 = Complex{Int16}(counter & 0xfff, (counter >> 12) & 0xfff)
+                z2 = Complex{Int16}((counter + 1) & 0xfff, ((counter + 1) >> 12) & 0xfff)
+                if bufs[1][j] != z1 || bufs[2][j] != z2
+                    show_mismatch && @warn("Error", received=(bufs[1][j], bufs[2][j]), expected=(z1, z2), at=j)
+                    error_count = error_count + 1
+                end
+                counter = counter + 0x2
+            end
+        end
+
+        @info "Data validation rate: $(Base.format_bytes(total_bytes / time_validation))/s, Total Bytes: $(Base.format_bytes(total_bytes))"
+
+        if error_count > 0
+            @warn "Total error count: $error_count/$(length(bufs[1]))"
+        end
+    end
+end
+
+function main()
+    for dev_args in Devices(driver="XTRX")
+        GC.enable(false)
+        try
+            #dma_test(dev_args; lfsr_mode=true)
+            dma_test(dev_args; lfsr_mode=false)
+        catch e
+            @error "Test failed" path=dev_args["path"] serial=dev_args["serial"] exception=(e, catch_backtrace())
+        end
+        GC.gc()
+    end
+end
+
+isinteractive() || main()

--- a/software/scripts/test_pattern_highlevel.jl
+++ b/software/scripts/test_pattern_highlevel.jl
@@ -33,7 +33,7 @@ function dma_test(dev_args;lfsr_mode=false, show_mismatch=false)
 
         # we want to go through the ring buffer a few times.        
         rd_nbufs = SoapySDR.SoapySDRDevice_getNumDirectAccessBuffers(dev, stream)
-        nbufs = 3 #rd_nbufs*3
+        nbufs = rd_nbufs*3
 
         # pre allocate memory to copy the data into.
         bufs = ntuple(_->Vector{chans[1].native_stream_format}(undef, mtu*nbufs), num_channels)
@@ -44,7 +44,7 @@ function dma_test(dev_args;lfsr_mode=false, show_mismatch=false)
 
         @info "Receiving data..."
         time_rd = @elapsed SoapySDR.activate!(stream) do
-            read!(stream, bufs)
+            read!(stream, bufs; timeout=1u"s")
         end
 
         @info "Data read rate: $(Base.format_bytes(total_bytes / time_rd))/s, Total Bytes: $(Base.format_bytes(total_bytes))"

--- a/software/soapysdr-xtrx/Streaming.cpp
+++ b/software/soapysdr-xtrx/Streaming.cpp
@@ -357,14 +357,16 @@ void SoapyXTRX::releaseWriteBuffer(SoapySDR::Stream */*stream*/, size_t handle,
     checked_ioctl(_fd, LITEPCIE_IOCTL_MMAP_DMA_READER_UPDATE, &mmap_dma_update);
 }
 
-void deinterleave(const int8_t *src, void *dst, uint32_t len, std::string format, size_t offset)
+void deinterleave(const void *src, size_t src_offset, void *dst, size_t dst_offset,
+                  size_t len, std::string format, size_t channel)
 {
     if (format == SOAPY_SDR_CS16) {
-        int16_t *samples_cs16 = (int16_t *)dst + offset * BYTES_PER_SAMPLE;
-        for (uint32_t i = offset; i < len; i += 2)
+        int16_t *src_cs16 = (int16_t *)src + 4*src_offset;
+        int16_t *dst_cs16 = (int16_t *)dst + 2*dst_offset;
+        for (uint32_t i = 0; i < len; i += 1)
         {
-            samples_cs16[i * BYTES_PER_SAMPLE] = (int16_t)(src[i * BYTES_PER_SAMPLE] << 8);
-            samples_cs16[i * BYTES_PER_SAMPLE + 1] = (int16_t)(src[i * BYTES_PER_SAMPLE + 1] << 8);
+            dst_cs16[2*i]     = src_cs16[4*i + channel];
+            dst_cs16[2*i + 1] = src_cs16[4*i + channel + 2];
         }
     }
     else {
@@ -372,14 +374,16 @@ void deinterleave(const int8_t *src, void *dst, uint32_t len, std::string format
     }
 }
 
-void interleave(const void *src, int8_t *dst, uint32_t len, std::string format, size_t offset)
+void interleave(const void *src, size_t src_offset, void *dst, size_t dst_offset,
+                size_t len, std::string format, size_t channel)
 {
     if (format == SOAPY_SDR_CS16) {
-        int16_t *samples_cs16 = (int16_t *)src + offset * BYTES_PER_SAMPLE;
-        for (uint32_t i = offset; i < len; i += 2)
+        int16_t *src_cs16 = (int16_t *)src + 2*src_offset;
+        int16_t *dst_cs16 = (int16_t *)dst + 4*dst_offset ;
+        for (uint32_t i = 0; i < len; i += 1)
         {
-            dst[i * BYTES_PER_SAMPLE] = (int8_t)(samples_cs16[i * BYTES_PER_SAMPLE] >> 8);
-            dst[i * BYTES_PER_SAMPLE + 1] = (int8_t)(samples_cs16[i * BYTES_PER_SAMPLE + 1] >> 8);
+            dst_cs16[4*i + channel] = src_cs16[2*i];
+            dst_cs16[4*i + channel + 2] = src_cs16[2*i + 1];
         }
     }
     else {
@@ -396,74 +400,75 @@ int SoapyXTRX::readStream(
     const long timeoutUs)
 {
     if (stream != RX_STREAM)
-    {
         return SOAPY_SDR_NOT_SUPPORTED;
-    }
-    size_t returnedElems = std::min(numElems, this->getStreamMTU(stream));
 
-    size_t samp_avail = 0;
+    // determine how many samples (of I and Q for both channels) we can process
+    size_t samples = std::min(numElems, getStreamMTU(stream));
 
-    if (_rx_stream.remainderHandle >= 0)
-    {
-        const size_t n = std::min(_rx_stream.remainderSamps, returnedElems);
+    // in the case of a split transaction, keep track of the amount of samples
+    // we processed already
+    size_t submitted_samples = 0;
 
-        if (n < returnedElems)
-        {
-            samp_avail = n;
+    if (_rx_stream.remainderHandle >= 0) {
+        // there is still some place left in the unsubmitted buffer, so fill
+        // it with as many new samples as possible
+        const size_t n = std::min(_rx_stream.remainderSamps, samples);
+
+        if (n < samples) {
+            // couldn't fit them all, so split the transaction
+            submitted_samples = n;
         }
 
-        // Read out channels
+        // unpack data
         for (size_t i = 0; i < _rx_stream.channels.size(); i++)
-        {
-            deinterleave(_rx_stream.remainderBuff + _rx_stream.remainderOffset * BYTES_PER_SAMPLE, buffs[i], n/2, _rx_stream.format, _rx_stream.channels[i]);
-        }
+            deinterleave(_rx_stream.remainderBuff, _rx_stream.remainderOffset/2,
+                         buffs[i], 0,
+                         n/2, _rx_stream.format, _rx_stream.channels[i]);
         _rx_stream.remainderSamps -= n;
         _rx_stream.remainderOffset += n;
 
         if (_rx_stream.remainderSamps == 0)
         {
-            this->releaseReadBuffer(stream, _rx_stream.remainderHandle);
+            releaseReadBuffer(stream, _rx_stream.remainderHandle);
             _rx_stream.remainderHandle = -1;
             _rx_stream.remainderOffset = 0;
         }
 
-        if (n == returnedElems)
-            return returnedElems;
+        // finish processing if all samples were processed
+        if (n == samples)
+            return samples;
     }
 
+    // get a new buffer
     size_t handle;
-    int ret = this->acquireReadBuffer(stream, handle, (const void **)&_rx_stream.remainderBuff, flags, timeNs, timeoutUs);
-
-    if (ret < 0)
-    {
-        if ((ret == SOAPY_SDR_TIMEOUT) && (samp_avail > 0))
-        {
-            return samp_avail;
-        }
+    int ret = acquireReadBuffer(stream, handle, (const void **)&_rx_stream.remainderBuff, flags, timeNs, timeoutUs);
+    if (ret < 0) {
+        // if we submitted something, we can ignore the timeout
+        if ((ret == SOAPY_SDR_TIMEOUT) && (submitted_samples > 0))
+            return submitted_samples;
         return ret;
     }
 
     _rx_stream.remainderHandle = handle;
     _rx_stream.remainderSamps = ret;
 
-    const size_t n = std::min((returnedElems - samp_avail), _rx_stream.remainderSamps);
+    const size_t n = std::min((samples - submitted_samples), _rx_stream.remainderSamps);
 
-    // Read out channels
+    // unpack data
     for (size_t i = 0; i < _rx_stream.channels.size(); i++)
-    {
-        deinterleave(_rx_stream.remainderBuff, buffs[i], n, _rx_stream.format, samp_avail + _rx_stream.channels[i]);
-    }
+        deinterleave(_rx_stream.remainderBuff, 0,
+                     buffs[i], submitted_samples/2,
+                     n/2, _rx_stream.format, _rx_stream.channels[i]);
     _rx_stream.remainderSamps -= n;
     _rx_stream.remainderOffset += n;
 
-    if (_rx_stream.remainderSamps == 0)
-    {
-        this->releaseReadBuffer(stream, _rx_stream.remainderHandle);
+    if (_rx_stream.remainderSamps == 0) {
+        releaseReadBuffer(stream, _rx_stream.remainderHandle);
         _rx_stream.remainderHandle = -1;
         _rx_stream.remainderOffset = 0;
     }
 
-    return returnedElems;
+    return samples;
 }
 
 int SoapyXTRX::writeStream(
@@ -475,74 +480,75 @@ int SoapyXTRX::writeStream(
     const long timeoutUs)
 {
     if (stream != TX_STREAM)
-    {
         return SOAPY_SDR_NOT_SUPPORTED;
-    }
 
-    size_t returnedElems = std::min(numElems, this->getStreamMTU(stream));
+    // determine how many samples (of I and Q for both channels) we can process
+    size_t samples = std::min(numElems, getStreamMTU(stream));
 
-    size_t samp_avail = 0;
+    // in the case of a split transaction, keep track of the amount of samples
+    // we processed already
+    size_t submitted_samples = 0;
 
-    if (_tx_stream.remainderHandle >= 0)
-    {
+    // is there still some place left in the unsubmitted buffer?
+    if (_tx_stream.remainderHandle >= 0) {
+        // there is still some place left in the unsubmitted buffer, so fill
+        // it with as many new samples as possible
+        const size_t n = std::min(_tx_stream.remainderSamps, samples);
 
-        const size_t n = std::min(_tx_stream.remainderSamps, returnedElems);
-
-        if (n < returnedElems)
-        {
-            samp_avail = n;
+        if (n < samples) {
+            // couldn't fit them all, so split the transaction
+            submitted_samples = n;
         }
 
-        // Write out channels
+        // pack data
         for (size_t i = 0; i < _tx_stream.channels.size(); i++)
-        {
-            interleave(buffs[i], _tx_stream.remainderBuff + _tx_stream.remainderOffset * BYTES_PER_SAMPLE, n/2, _tx_stream.format, _tx_stream.channels[i]);
-        }
+            interleave(buffs[i], 0,
+                       _tx_stream.remainderBuff, _tx_stream.remainderOffset/2,
+                       n/2, _tx_stream.format, _tx_stream.channels[i]);
         _tx_stream.remainderSamps -= n;
         _tx_stream.remainderOffset += n;
 
         if (_tx_stream.remainderSamps == 0)
         {
-            this->releaseWriteBuffer(stream, _tx_stream.remainderHandle, _tx_stream.remainderOffset, flags, timeNs);
+            releaseWriteBuffer(stream, _tx_stream.remainderHandle,
+                               _tx_stream.remainderOffset, flags, timeNs);
             _tx_stream.remainderHandle = -1;
             _tx_stream.remainderOffset = 0;
         }
 
-        if (n == returnedElems)
-            return returnedElems;
+        // finish processing if all samples were processed
+        if (n == samples)
+            return samples;
     }
 
+    // get a new buffer
     size_t handle;
-
-    int ret = this->acquireWriteBuffer(stream, handle, (void **)&_tx_stream.remainderBuff, timeoutUs);
-    if (ret < 0)
-    {
-        if ((ret == SOAPY_SDR_TIMEOUT) && (samp_avail > 0))
-        {
-            return samp_avail;
-        }
+    int ret = acquireWriteBuffer(stream, handle, (void **)&_tx_stream.remainderBuff, timeoutUs);
+    if (ret < 0) {
+        // if we submitted something, we can ignore the timeout
+        if ((ret == SOAPY_SDR_TIMEOUT) && (submitted_samples > 0))
+            return submitted_samples;
         return ret;
     }
 
     _tx_stream.remainderHandle = handle;
     _tx_stream.remainderSamps = ret;
 
-    const size_t n = std::min((returnedElems - samp_avail), _tx_stream.remainderSamps);
+    const size_t n = std::min((samples - submitted_samples), _tx_stream.remainderSamps);
 
-    // Write out channels
+    // pack data
     for (size_t i = 0; i < _tx_stream.channels.size(); i++)
-    {
-        interleave(buffs[i], _tx_stream.remainderBuff, n, _tx_stream.format, samp_avail + _tx_stream.channels[i]);
-    }
+        interleave(buffs[i], submitted_samples/2,
+                   _tx_stream.remainderBuff, 0,
+                   n/2, _tx_stream.format, _tx_stream.channels[i]);
     _tx_stream.remainderSamps -= n;
     _tx_stream.remainderOffset += n;
 
-    if (_tx_stream.remainderSamps == 0)
-    {
-        this->releaseWriteBuffer(stream, _tx_stream.remainderHandle, _tx_stream.remainderOffset, flags, timeNs);
+    if (_tx_stream.remainderSamps == 0) {
+        releaseWriteBuffer(stream, _tx_stream.remainderHandle, _tx_stream.remainderOffset, flags, timeNs);
         _tx_stream.remainderHandle = -1;
         _tx_stream.remainderOffset = 0;
     }
 
-    return returnedElems;
+    return samples;
 }

--- a/software/soapysdr-xtrx/Streaming.cpp
+++ b/software/soapysdr-xtrx/Streaming.cpp
@@ -377,16 +377,19 @@ void deinterleave(const void *src, size_t src_offset, void* const* dst, size_t d
     }
 }
 
-void interleave(const void *src, size_t src_offset, void *dst, size_t dst_offset,
-                size_t len, std::string format, size_t channel)
+void interleave(const void* const* src, size_t src_offset, void *dst, size_t dst_offset,
+                size_t len, std::string format)
 {
     if (format == SOAPY_SDR_CS16) {
-        int16_t *src_cs16 = (int16_t *)src + 2*src_offset;
+        int16_t *src_cs16_0 = (int16_t *)src[0] + 2*src_offset;
+        int16_t *src_cs16_1 = (int16_t *)src[1] + 2*src_offset;
         int16_t *dst_cs16 = (int16_t *)dst + 4*dst_offset;
-        for (uint32_t i = 0; i < len; i += 1)
+        for (uint32_t i = 0; i < len/2; i += 1)
         {
-            dst_cs16[4*i + channel*2] = src_cs16[2*i];
-            dst_cs16[4*i + channel*2 + 1] = src_cs16[2*i + 1];
+            dst_cs16[4*i]     = src_cs16_0[i*2];
+            dst_cs16[4*i + 1] = src_cs16_0[i*2 + 1];
+            dst_cs16[4*i + 2] = src_cs16_1[i*2];
+            dst_cs16[4*i + 3] = src_cs16_1[i*2 + 1];
         }
     }
     else {
@@ -480,7 +483,7 @@ int SoapyXTRX::writeStream(
         return SOAPY_SDR_NOT_SUPPORTED;
 
     // determine how many samples (of I and Q for both channels) we can process
-    size_t samples = std::min(numElems, getStreamMTU(stream));
+    size_t samples = std::min(numElems*2, getStreamMTU(stream)*2);
 
     // in the case of a split transaction, keep track of the amount of samples
     // we processed already
@@ -499,9 +502,9 @@ int SoapyXTRX::writeStream(
 
         // pack data
         for (size_t i = 0; i < _tx_stream.channels.size(); i++)
-            interleave(buffs[i], 0,
+            interleave(buffs, 0,
                        _tx_stream.remainderBuff, _tx_stream.remainderOffset/2,
-                       n/2, _tx_stream.format, _tx_stream.channels[i]);
+                       n, _tx_stream.format);
         _tx_stream.remainderSamps -= n;
         _tx_stream.remainderOffset += n;
 
@@ -515,29 +518,25 @@ int SoapyXTRX::writeStream(
 
         // finish processing if all samples were processed
         if (n == samples)
-            return samples;
+            return samples/2;
     }
 
     // get a new buffer
     size_t handle;
     int ret = acquireWriteBuffer(stream, handle, (void **)&_tx_stream.remainderBuff, timeoutUs);
     if (ret < 0) {
-        // if we submitted something, we can ignore the timeout
-        if ((ret == SOAPY_SDR_TIMEOUT) && (submitted_samples > 0))
-            return submitted_samples;
         return ret;
     }
 
     _tx_stream.remainderHandle = handle;
-    _tx_stream.remainderSamps = ret;
+    _tx_stream.remainderSamps = ret*2;
 
     const size_t n = std::min((samples - submitted_samples), _tx_stream.remainderSamps);
 
     // pack data
-    for (size_t i = 0; i < _tx_stream.channels.size(); i++)
-        interleave(buffs[i], submitted_samples/2,
-                   _tx_stream.remainderBuff, 0,
-                   n/2, _tx_stream.format, _tx_stream.channels[i]);
+    interleave(buffs, submitted_samples/2,
+                _tx_stream.remainderBuff, 0,
+                n, _tx_stream.format);
     _tx_stream.remainderSamps -= n;
     _tx_stream.remainderOffset += n;
 
@@ -547,5 +546,5 @@ int SoapyXTRX::writeStream(
         _tx_stream.remainderOffset = 0;
     }
 
-    return samples;
+    return samples/2;
 }

--- a/software/soapysdr-xtrx/Streaming.cpp
+++ b/software/soapysdr-xtrx/Streaming.cpp
@@ -365,8 +365,8 @@ void deinterleave(const void *src, size_t src_offset, void *dst, size_t dst_offs
         int16_t *dst_cs16 = (int16_t *)dst + 2*dst_offset;
         for (uint32_t i = 0; i < len; i += 1)
         {
-            dst_cs16[2*i]     = src_cs16[4*i + channel];
-            dst_cs16[2*i + 1] = src_cs16[4*i + channel + 2];
+            dst_cs16[2*i]     = src_cs16[4*i + 2*channel];
+            dst_cs16[2*i + 1] = src_cs16[4*i + 2*channel + 1];
         }
     }
     else {
@@ -382,8 +382,8 @@ void interleave(const void *src, size_t src_offset, void *dst, size_t dst_offset
         int16_t *dst_cs16 = (int16_t *)dst + 4*dst_offset ;
         for (uint32_t i = 0; i < len; i += 1)
         {
-            dst_cs16[4*i + channel] = src_cs16[2*i];
-            dst_cs16[4*i + channel + 2] = src_cs16[2*i + 1];
+            dst_cs16[4*i + channel*2] = src_cs16[2*i];
+            dst_cs16[4*i + channel*2 + 1] = src_cs16[2*i + 1];
         }
     }
     else {


### PR DESCRIPTION
Together with https://github.com/JuliaTelecom/SoapySDR.jl/pull/78, the following seems to make sense now (at least when inspecting the data we get back on the loopback; didn't test actualy Tx/Rx):

`simple_loopback_multichannel.jl`
```julia
ENV["SOAPY_SDR_LOG_LEVEL"] = "DEBUG"

using SoapySDR, Printf, Unitful

#SoapySDR.register_log_handler()

function loopback_test(num_channels=2)
    # open the first device
    devs = Devices(parse(KWArgs, "driver=XTRX"))
    dev = Device(devs[1])

    # get the RX and TX channels
    chan_rx = SoapySDR.Channel[]
    chan_tx = SoapySDR.Channel[]
    for i in 1:num_channels
        push!(chan_rx, dev.rx[i])
        push!(chan_tx, dev.tx[i])
    end

    # enable a loopback
    SoapySDR.SoapySDRDevice_writeSetting(dev, "LOOPBACK_ENABLE", "TRUE")

    # open RX and TX streams
    format = Complex{Int16} #chan_rx.native_stream_format
    stream_rx = SoapySDR.Stream(format, chan_rx)
    stream_tx = SoapySDR.Stream(format, chan_tx)

    # properties that matter for the buffers we'll be using
    mtu = Int(stream_tx.mtu)

    try
        wr_cnt = 0
        rd_cnt = 0
        should_transmit() = wr_cnt < 999
        should_receive() = rd_cnt < 3000
        # NOTE: we read more buffers in case there's delay between TX and RX

        SoapySDR.activate!(stream_rx)
        SoapySDR.activate!(stream_tx)

        while should_transmit() || should_receive()
            if should_transmit()
                buffs = []
                for i in 1:num_channels
                    buf = Vector{format}(undef, mtu)
                    buf .= (2*num_channels*wr_cnt+1+(i-1)*num_channels)+(2*num_channels*wr_cnt+2+(i-1)*num_channels)im
                    push!(buffs, buf)
                end
                write(stream_tx, tuple(buffs...))
                wr_cnt += 1
            end

            if should_receive()
                buffs = []
                for i in 1:num_channels
                    buf = Vector{format}(undef, mtu)
                    push!(buffs, buf)
                end
                read!(stream_rx, tuple(buffs...); timeout=5u"s")
                rd_cnt += 1

                if rd_cnt % 32 == 0
                    println()
                end
                @printf("%3d ", real(buffs[1][1]))
            end
        end
        println()
    finally
        SoapySDR.deactivate!(stream_tx)
        SoapySDR.deactivate!(stream_rx)

        # close everything
        finalize.([stream_rx, stream_tx])
        finalize(dev)
    end
end

isinteractive() || loopback_test()
isinteractive() || loopback_test()
```