### PR TITLE
Remove `fpga-source` submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,10 +2,6 @@
 	path = software/rx_tools
 	url = https://github.com/JuliaComputing/rx_tools
 	shallow = true
-[submodule "software/fpga-source"]
-	path = software/fpga-source
-	url = https://github.com/xtrx-sdr/fpga-source.git
-	shallow = true
 [submodule "software/LMS7002M-driver"]
 	path = software/LMS7002M-driver
 	url = https://github.com/JuliaComputing/LMS7002M-driver


### PR DESCRIPTION
We don't need to use submodules to track fairwaves stuff since it's not a moving target, and it's nice to not have to download it when we download all the other submodules.

We still have the `make -C software fairwaves` target to download all the fairwaves stuff, if you need it for local development.