### PR TITLE
Automatically set CGEN to 8x samplerate

### DIFF
--- a/software/scripts/acquire_iq.jl
+++ b/software/scripts/acquire_iq.jl
@@ -69,8 +69,7 @@ function do_txrx(mode::Symbol;
         fullscale = dev.tx[1].fullscale
 
         frequency = 1575.00u"MHz"
-        #sample_rate = 6u"MHz"
-        sample_rate = 30.720000u"MHz"/4 # The TSP likes this in power of two factors
+        sample_rate = 8u"MHz"
 
         # Setup transmission/recieve parameters
         for (c_idx, cr) in enumerate(dev.rx)

--- a/software/soapysdr-xtrx/XTRXDevice.hpp
+++ b/software/soapysdr-xtrx/XTRXDevice.hpp
@@ -158,7 +158,7 @@ class DLL_EXPORT SoapyXTRX : public SoapySDR::Device {
     std::map<int, std::map<size_t, double>> _cachedFilterBws;
 
     // Clocking API
-    double getTSPRate(const int direction) const;
+    double getTSPRate() const;
     void setMasterClockRate(const double rate) override;
     double getMasterClockRate(void) const override;
     void setReferenceClockRate(const double rate) override;


### PR DESCRIPTION
This automatically sets `CGEN` to a default value when setting the samplerate of a Tx or Rx stream.  Note that although the SoapySDR API makes it seem like the Tx and Rx samplerates are independent, they are rather tightly coupled by the LMS7002M chip.  While there is some flexibility in the chip, we are likely never going to make use of a full duplex operation where the samplerates are different, so I have opted to take the simple approach and simplify the codebase to instead hint to the developer (where allowed by the SoapySDR API) that there is actually only a single TSP rate.

With this change we get much more reliably smooth looking transmissions, although as the samplerate increases we still get a bunch of noise and other issues.  I suspect improper reference clock tuning may be an issue here, and so further experimentation will have to wait for that to get sorted.

Closes #73