### PR TITLE
Cleanup GPS init

### DIFF
--- a/software/scripts/gps_dump.jl
+++ b/software/scripts/gps_dump.jl
@@ -1,0 +1,21 @@
+using SoapySDR
+using XTRX: CSRs
+
+dev = Device(Devices(driver="XTRX", serial="134c5241b884854")[1])
+#dev = Device(Devices(driver="XTRX")[2])
+
+@info "Restarting GPS..."
+dev[SoapySDR.Setting("GPS_ENABLE")] = "FALSE"
+
+sleep(2)
+@info "Enabling GPS..."
+dev[SoapySDR.Setting("GPS_ENABLE")] = "TRUE"
+
+# Enable PPS in/out
+SoapySDR.SoapySDRDevice_writeRegister(dev.ptr, "LitePCI", CSRs.CSR_SYNCHRO_CONTROL_ADDR,
+    (0b0001 << CSRs.CSR_SYNCHRO_CONTROL_INT_SOURCE_OFFSET) | (0b0001 << CSRs.CSR_SYNCHRO_CONTROL_OUT_SOURCE_OFFSET))
+
+while true
+    ret = unsafe_string(SoapySDR.SoapySDRDevice_readUART(dev, "GPS", 100000))
+    isempty(ret) || print(ret)
+end

--- a/software/soapysdr-xtrx/XTRXDevice.cpp
+++ b/software/soapysdr-xtrx/XTRXDevice.cpp
@@ -1264,15 +1264,18 @@ void SoapyXTRX::writeUART(const std::string &which, const std::string &data) {}
 std::string SoapyXTRX::readUART(const std::string &which, const long timeoutUs = 100000) const {
     std::string ret_str = "";
     if (which == "GPS") {
-        auto ts = std::chrono::microseconds();
+        auto tstart = std::chrono::high_resolution_clock::now();
         while (true) {
             char c;
             if (litepcie_readl(_fd, CSR_GPS_UART_RXEMPTY_ADDR) == 0) {
                 c = litepcie_readl(_fd, CSR_GPS_UART_RXTX_ADDR);
                 ret_str.push_back(c);
             }
-            if (std::chrono::microseconds() - ts > std::chrono::microseconds(timeoutUs) || c == '\n')
+            auto elapsed = std::chrono::high_resolution_clock::now() - tstart;
+            long long elapsedUs = std::chrono::duration_cast<std::chrono::microseconds>(elapsed).count();
+            if (elapsedUs > timeoutUs || c == '\n' || c == '\r') {
                 break;
+            }
         }
         return ret_str;
     }

--- a/software/soapysdr-xtrx/XTRXDevice.cpp
+++ b/software/soapysdr-xtrx/XTRXDevice.cpp
@@ -1225,10 +1225,10 @@ void SoapyXTRX::writeSetting(const std::string &key, const std::string &value) {
     } else if (key == "GPS_ENABLE") {
         if (value == "TRUE") {
             SoapySDR::log(SOAPY_SDR_DEBUG, "Enabling GPS");
-            litepcie_writel(_fd, CSR_GPS_CONTROL_ADDR, 1 * (1 << CSR_GPS_CONTROL_ENABLE_OFFSET));
+            litepcie_writel(_fd, CSR_GPS_CONTROL_ADDR, 0 * (1 << CSR_GPS_CONTROL_ENABLE_OFFSET));
         } else if (value == "FALSE") {
             SoapySDR::log(SOAPY_SDR_DEBUG, "Disabling GPS");
-            litepcie_writel(_fd, CSR_GPS_CONTROL_ADDR, 0 * (1 << CSR_GPS_CONTROL_ENABLE_OFFSET));
+            litepcie_writel(_fd, CSR_GPS_CONTROL_ADDR, 1 * (1 << CSR_GPS_CONTROL_ENABLE_OFFSET));
         } else {
             throw std::runtime_error("SoapyXTRX::writeSetting(" + key + ", " +
                                      value + ") unknown value");

--- a/software/soapysdr-xtrx/XTRXDevice.cpp
+++ b/software/soapysdr-xtrx/XTRXDevice.cpp
@@ -1233,15 +1233,6 @@ void SoapyXTRX::writeSetting(const std::string &key, const std::string &value) {
             throw std::runtime_error("SoapyXTRX::writeSetting(" + key + ", " +
                                      value + ") unknown value");
         }
-    } else if (key == "GPS_DUMP") {
-        litepcie_writel(_fd, CSR_GPS_CONTROL_ADDR, 1 * (1 << CSR_GPS_CONTROL_ENABLE_OFFSET));
-        // Argument is the number of seconds
-        int iters = std::stoi(value)*100000;
-        for (int i = 0; i < iters; i++) {
-            if (litepcie_readl(_fd, CSR_GPS_UART_RXEMPTY_ADDR) == 0)
-                SoapySDR::logf(SOAPY_SDR_INFO, "%c", litepcie_readl(_fd, CSR_GPS_UART_RXTX_ADDR));
-            usleep(10);
-        }
     } else
         throw std::runtime_error("SoapyXTRX::writeSetting(" + key + ", " +
                                  value + ") unknown key");


### PR DESCRIPTION
Fixes up some regressions in the GPS Enable and UART:
```
sjkelly@pathfinder:~/xtrx_julia/software (sjk/ppscal1=)$ julia --project ./scripts/gps_dump.jl 
[INFO] SoapyXTRX initializing...
[INFO] Opened devnode /dev/litepcie8, serial 134c5241b884854
[INFO] LMS7002M info: revision 1, version 7
[INFO] CGEN tune 80.000000 MHz (fref=26.000000 MHz) begin
[INFO] SoapyXTRX initialization complete
[ Info: Restarting GPS...
[ Info: Enabling GPS...
$PMTK011,MTKGPS*08
$PMTK010,001*2E
$PMTK011,MTKGPS*08
$PMTK010,002*2D
$GNGGA,235943.100,,,,,0,0,,,M,,M,,*5D
$GPGSA,A,1,,,,,,,,,,,,,,,*1E
$GLGSA,A,1,,,,,,,,,,,,,,,*02
$GPGSV,1,1,00*79
$GLGSV,1,1,00*65
$GNRMC,235943.100,V,,,,,0.00,0.00,050180,,,N*54
$GNVTG,0.00,T,,M,0.00,N,0.00,K,N*2C
$GNGGA,235944.100,,,,,0,0,,,M,,M,,*5A
$GPGSA,A,1,,,,,,,,,,,,,,,*1E
$GLGSA,A,1,,,,,,,,,,,,,,,*02
$GPGSV,1,1,00*79
$GLGSV,1,1,00*65
$GNRMC,235944.100,V,,,,,0.00,0.00,050180,,,N*53
```