### PR TITLE
Bump targeted kernel release to v5.16.0

### DIFF
--- a/software/Makefile.kernel
+++ b/software/Makefile.kernel
@@ -12,8 +12,8 @@ else
 KERNEL_PATH ?= $(REPO_DIR)/software/kernel
 
 KERNEL_URL := https://github.com/torvalds/linux.git
-KERNEL_VERSION ?= v5.15
-KERNEL_FULLVERSION ?= 5.15.0
+KERNEL_VERSION ?= v5.16
+KERNEL_FULLVERSION ?= 5.16.0
 
 kernel/.git/HEAD:
 	git clone --depth=1 -b $(KERNEL_VERSION) $(KERNEL_URL) kernel


### PR DESCRIPTION
Keno wants to target 5.16 for xtrxbot to get firmware for some devices on the board.