### PR TITLE
DAC Tuning of VCTCXO

### DIFF
--- a/software/scripts/clock_cal.jl
+++ b/software/scripts/clock_cal.jl
@@ -16,7 +16,7 @@ for dev in Devices(driver="XTRX")
                 for _ in 1:trials
                     SoapySDR.SoapySDRDevice_writeRegister(d, "LitePCI", latch_addr, 1)
                     before = SoapySDR.SoapySDRDevice_readRegister(d, "LitePCI", cycles_addr)
-                    sleep(1)
+                    Base.Libc.systemsleep(1)
                     SoapySDR.SoapySDRDevice_writeRegister(d, "LitePCI", latch_addr, 1)
                     after = SoapySDR.SoapySDRDevice_readRegister(d, "LitePCI", cycles_addr)
                     println("VCTCXO clock for $clksrc:", after-before)

--- a/software/scripts/clock_cal.jl
+++ b/software/scripts/clock_cal.jl
@@ -4,26 +4,41 @@ using XTRX: CSRs
 
 trials = 2
 
-latch_addr = CSRs.CSR_BASE | CSRs.CSR_VCTCXO_CYCLES_LATCH_ADDR
-cycles_addr = CSRs.CSR_BASE | CSRs.CSR_VCTCXO_CYCLES_ADDR
+const latch_addr = CSRs.CSR_BASE | CSRs.CSR_VCTCXO_CYCLES_LATCH_ADDR
+const cycles_addr = CSRs.CSR_BASE | CSRs.CSR_VCTCXO_CYCLES_ADDR
+
+function get_cycles(d)
+    SoapySDR.SoapySDRDevice_writeRegister(d, "LitePCI", latch_addr, 1)
+    before = SoapySDR.SoapySDRDevice_readRegister(d, "LitePCI", cycles_addr)
+    Base.Libc.systemsleep(1)
+    SoapySDR.SoapySDRDevice_writeRegister(d, "LitePCI", latch_addr, 1)
+    after = SoapySDR.SoapySDRDevice_readRegister(d, "LitePCI", cycles_addr)
+    return after - before
+end
 
 for dev in Devices(driver="XTRX")
     println("Checking VCTCXO clock")
     try
         Device(dev) do d
-            for clksrc in d.clock_sources
-                d.clock_source = clksrc
-                for _ in 1:trials
-                    SoapySDR.SoapySDRDevice_writeRegister(d, "LitePCI", latch_addr, 1)
-                    before = SoapySDR.SoapySDRDevice_readRegister(d, "LitePCI", cycles_addr)
-                    Base.Libc.systemsleep(1)
-                    SoapySDR.SoapySDRDevice_writeRegister(d, "LitePCI", latch_addr, 1)
-                    after = SoapySDR.SoapySDRDevice_readRegister(d, "LitePCI", cycles_addr)
-                    println("VCTCXO clock for $clksrc:", after-before)
+            if "--dac" in ARGS
+                for i in 0:15
+                    dac_val = UInt16(i)*0x111
+                    d[SoapySDR.Setting("DAC_SET")] = string(dac_val)
+                    cycles = get_cycles(d)
+                    println("VCTCXO clock:", cycles, " (DAC_SET=$(repr(dac_val))")
+                end
+            else
+                for clksrc in d.clock_sources
+                    d.clock_source = clksrc
+                    for _ in 1:trials
+                        cycles = get_cycles(d)
+                        println("VCTCXO clock for $clksrc:", cycles)
+                    end
                 end
             end
         end
     catch e
+        print(e)
         @warn "Device failed"
     end
 end

--- a/software/soapysdr-xtrx/XTRXDevice.cpp
+++ b/software/soapysdr-xtrx/XTRXDevice.cpp
@@ -1238,7 +1238,9 @@ void SoapyXTRX::writeSetting(const std::string &key, const std::string &value) {
             throw std::runtime_error("SoapyXTRX::writeSetting(" + key + ", " +
                                      value + ") unknown value");
         }
-    } else
+    } else if (key == "DAC_SET") {
+        vctcxo_dac_set(std::stoi(value));
+    }else
         throw std::runtime_error("SoapyXTRX::writeSetting(" + key + ", " +
                                  value + ") unknown key");
 }
@@ -1334,7 +1336,7 @@ void SoapyXTRX::vctcxo_dac_set(int value) {
         cmd = 0x08;
         ret = i2c1_write(DAC60501_I2C_ADDR, cmd, dat, 2);
         if (!ret) {
-            printf("DAC write failed\n");
+            printf("DAC write failed, err: %d\n", ret);
         }
     }
 }

--- a/software/soapysdr-xtrx/XTRXDevice.hpp
+++ b/software/soapysdr-xtrx/XTRXDevice.hpp
@@ -400,6 +400,12 @@ class DLL_EXPORT SoapyXTRX : public SoapySDR::Device {
     bool i2c1_poll(unsigned char slave_addr) const;
     void i2c1_scan(void) const;
 
+    int board_get_revision(void);
+    void vctcxo_dac_set(int value);
+
+    int board_revision;
+    int dac_addr;
+
     int _fd;
     LMS7002M_t *_lms;
     double _masterClockRate;


### PR DESCRIPTION
This allows us to set the DAC from SoapySDR. Though measuring and calibrating from the host is super noisy. Ultimately we will want to have the latch set by PPS. Soeren noted that the untuned VCTCXO should be more than precise enough for our needs. Using `Base.Libc.systemsleep` we measured about a 0.2% error, far less than other readings we have taken. There is more infrastructure here we will eventually want, so this is likely a reasonable intermediate merge while we track down other issues.