### PR TITLE
[soapysdr] support dumping of Litex registers

### DIFF
--- a/software/soapysdr-xtrx/XTRXDevice.hpp
+++ b/software/soapysdr-xtrx/XTRXDevice.hpp
@@ -406,6 +406,8 @@ class DLL_EXPORT SoapyXTRX : public SoapySDR::Device {
     int board_revision;
     int dac_addr;
 
+    void dump_litex_regs(std::string ini);
+
     int _fd;
     LMS7002M_t *_lms;
     double _masterClockRate;


### PR DESCRIPTION
Example use:

```
using SoapySDR
dev = Device(Devices(driver="XTRX")[2])
dev[SoapySDR.Setting("LITEX_DUMP_INI")] = "litex_dump.ini"
```

Yields:
```
[FILE INFO]
type=litex csr configuration
version=1.0
[VCTCXO]
0xf000c000=0x00000000
0xf000c004=0x00000000
[RF_SWITCHES]
0xf000c800=0x00000001
[LMS]
0xf000d000=0x00000300
0xf000d004=0x00000001
0xf000d008=0x00001010
0xf000d00c=0x00002001
0xf000d010=0x00000001
0xf000d014=0x820107ff
0xf000d018=0x00000000
0xf000d01c=0x00000001
0xf000d020=0x00000000
0xf000d024=0x00000000
0xf000d028=0x00000000
```