### PR TITLE
Fix overflow / underflow stats

### DIFF
--- a/software/LibSigflow.jl/src/LibSigflow.jl
+++ b/software/LibSigflow.jl/src/LibSigflow.jl
@@ -132,8 +132,14 @@ function stream_data(s_rx::SoapySDR.Stream{T}, end_condition::Union{Integer,Base
         try
             read!(s_rx, split_matrix(buff); flags, throw_error = true)
         catch e
-            if e isa SoapySDR.SoapySDRDeviceError && e.status == SoapySDR.SOAPY_SDR_OVERFLOW
-                _num_overflows[] += 1
+            if e isa SoapySDR.SoapySDRDeviceError
+                if e.status == SoapySDR.SOAPY_SDR_OVERFLOW
+                    _num_overflows[] += 1
+                elseif e.status == SoapySDR.SOAPY_SDR_TIMEOUT
+                    println("Tᵣ")
+                else
+                    println("Eᵣ")
+                end
             else
                 rethrow(e)
             end
@@ -164,9 +170,9 @@ function stream_data(s_tx::SoapySDR.Stream{T}, in::Channel{Matrix{T}}) where {T 
                         if e.status == SoapySDR.SOAPY_SDR_UNDERFLOW
                             _num_underflows[] += 1
                         elseif e.status == SoapySDR.SOAPY_SDR_TIMEOUT
-                            println("T")
+                            println("Tₜ")
                         else
-                            println("E")
+                            println("Eₜ")
                         end
                     else
                         rethrow(e)

--- a/software/LibSigflow.jl/src/LibSigflow.jl
+++ b/software/LibSigflow.jl/src/LibSigflow.jl
@@ -135,10 +135,11 @@ function stream_data(s_rx::SoapySDR.Stream{T}, end_condition::Union{Integer,Base
             if e isa SoapySDR.SoapySDRDeviceError
                 if e.status == SoapySDR.SOAPY_SDR_OVERFLOW
                     _num_overflows[] += 1
+                    print("O")
                 elseif e.status == SoapySDR.SOAPY_SDR_TIMEOUT
-                    println("Tᵣ")
+                    print("Tᵣ")
                 else
-                    println("Eᵣ")
+                    print("Eᵣ")
                 end
             else
                 rethrow(e)
@@ -169,10 +170,11 @@ function stream_data(s_tx::SoapySDR.Stream{T}, in::Channel{Matrix{T}}) where {T 
                     if e isa SoapySDR.SoapySDRDeviceError
                         if e.status == SoapySDR.SOAPY_SDR_UNDERFLOW
                             _num_underflows[] += 1
+                            print("U")
                         elseif e.status == SoapySDR.SOAPY_SDR_TIMEOUT
-                            println("Tₜ")
+                            print("Tₜ")
                         else
-                            println("Eₜ")
+                            print("Eₜ")
                         end
                     else
                         rethrow(e)


### PR DESCRIPTION
Overflow and underflow stats are not included within flags, but are thrown in SoapySDR.jl:
https://github.com/JuliaTelecom/SoapySDR.jl/blob/0f2ea919a99c5acd0278de1042a00aecf8d6cdd1/src/highlevel.jl#L814