### PR TITLE
replace `pci_set_dma_mask` with `dma_set_mask`

### DIFF
--- a/software/litepcie-kernel-module/main.c
+++ b/software/litepcie-kernel-module/main.c
@@ -1341,7 +1341,7 @@ static int litepcie_pci_probe(struct pci_dev *dev, const struct pci_device_id *i
 	dev_info(&dev->dev, "Version %s\n", fpga_identifier);
 
 	pci_set_master(dev);
-	ret = pci_set_dma_mask(dev, DMA_BIT_MASK(32));
+	ret = set_dma_mask(dev->dev, DMA_BIT_MASK(32));
 	if (ret) {
 		dev_err(&dev->dev, "Failed to set DMA mask\n");
 		goto fail1;


### PR DESCRIPTION
This call was deprecated in Linux 5.18

