### PR TITLE
add support for non-pro XTRX variants

### DIFF
--- a/fairwaves_xtrx.py
+++ b/fairwaves_xtrx.py
@@ -92,8 +92,8 @@ class BaseSoC(SoCCore):
         "xsync_spi"   : 27,
         "synchro"     : 28,
     }
-    def __init__(self, sys_clk_freq=int(125e6), with_cpu=True, cpu_firmware=None, with_jtagbone=True, with_analyzer=False):
-        platform = fairwaves_xtrx.Platform()
+    def __init__(self, sys_clk_freq=int(125e6), with_cpu=True, cpu_firmware=None, with_jtagbone=True, with_analyzer=False, nonpro=False):
+        platform = fairwaves_xtrx.Platform(nonpro=nonpro)
 
         git_sha = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD']).strip().decode('utf-8')
         git_dirty = "-dirty" if len(subprocess.check_output(['git', 'diff'])) != 0 else ""
@@ -155,7 +155,7 @@ class BaseSoC(SoCCore):
             cd         = "pcie"
         )
         self.add_pcie(phy=self.pcie_phy, address_width=64, ndmas=1,
-            with_dma_buffering = True, dma_buffering_depth=16384,
+            with_dma_buffering = True, dma_buffering_depth=8192 if nonpro else 16384,
             with_dma_loopback  = True,
             with_synchronizer  = True,
             with_msi           = True
@@ -254,6 +254,7 @@ def main():
     parser.add_argument("--build",  action="store_true", help="Build bitstream")
     parser.add_argument("--load",   action="store_true", help="Load bitstream")
     parser.add_argument("--flash",  action="store_true", help="Flash bitstream")
+    parser.add_argument("--nonpro",  action="store_true", help="Generate a bitstream for the non-pro XTRX using the 35T FPGA")
     parser.add_argument("--driver", action="store_true", help="Generate PCIe driver from LitePCIe (override local version).")
     args = parser.parse_args()
 
@@ -261,7 +262,7 @@ def main():
     for run in range(2):
         prepare = (run == 0)
         build   = ((run == 1) & args.build)
-        soc = BaseSoC(cpu_firmware=None if prepare else "firmware/firmware.bin")
+        soc = BaseSoC(cpu_firmware=None if prepare else "firmware/firmware.bin", nonpro=args.nonpro)
         builder = Builder(soc, csr_csv="csr.csv")
         builder.build(run=build)
         if prepare:

--- a/fairwaves_xtrx_platform.py
+++ b/fairwaves_xtrx_platform.py
@@ -176,9 +176,19 @@ _io = [
 class Platform(XilinxPlatform):
     default_clk_name   = "clk60"
     default_clk_period = 1e9/60e6
+    dev_string = ""
+    dev_short_string = ""
 
-    def __init__(self):
-        XilinxPlatform.__init__(self, "xc7a50tcpg236-2", _io, toolchain="vivado")
+    def __init__(self, nonpro=False):
+        # Pro and non-Pro boards have different FPGA part numbers, but same pins
+        if nonpro:
+            self.dev_string = "xc7a50tcpg236-2"
+            self.dev_short_string = "a50t"
+        else:
+            self.dev_string = "xc7a35tcpg236-3"
+            self.dev_short_string = "a35t"
+
+        XilinxPlatform.__init__(self, self.dev_string, _io, toolchain="vivado")
 
         self.toolchain.bitstream_commands = [
             "set_property BITSTREAM.CONFIG.UNUSEDPIN Pulldown [current_design]",
@@ -210,7 +220,7 @@ class Platform(XilinxPlatform):
         ]
 
     def create_programmer(self):
-        return OpenOCD("openocd_xc7_ft232.cfg", "bscan_spi_xc7a50t.bit")
+        return OpenOCD("openocd_xc7_ft232.cfg", "bscan_spi_xc7"+self.dev_short_string+".bit")
 
     def do_finalize(self, fragment):
         XilinxPlatform.do_finalize(self, fragment)

--- a/fairwaves_xtrx_platform.py
+++ b/fairwaves_xtrx_platform.py
@@ -182,11 +182,11 @@ class Platform(XilinxPlatform):
     def __init__(self, nonpro=False):
         # Pro and non-Pro boards have different FPGA part numbers, but same pins
         if nonpro:
-            self.dev_string = "xc7a50tcpg236-2"
-            self.dev_short_string = "a50t"
-        else:
             self.dev_string = "xc7a35tcpg236-3"
             self.dev_short_string = "a35t"
+        else:
+            self.dev_string = "xc7a50tcpg236-2"
+            self.dev_short_string = "a50t"
 
         XilinxPlatform.__init__(self, self.dev_string, _io, toolchain="vivado")
 

--- a/software/__init__.py
+++ b/software/__init__.py
@@ -15,11 +15,11 @@ def generate_litepcie_software_headers(soc, dst):
     tools.write_to_file(os.path.join(dst, "mem.h"), mem_header)
 
 def generate_litepcie_software(soc, dst, use_litepcie_software=False):
+    gen_module_dir = os.path.join(dst, "kernel")
+    our_module_dir = os.path.join(dst, "litepcie-kernel-module")
+    gen_user_dir = os.path.join(dst, "user")
+    our_user_dir = os.path.join(dst, "litepcie-user-library")
     if use_litepcie_software:
-        gen_module_dir = os.path.join(dst, "kernel")
-        our_module_dir = os.path.join(dst, "litepcie-kernel-module")
-        gen_user_dir = os.path.join(dst, "user")
-        our_user_dir = os.path.join(dst, "litepcie-user-library")
         cdir = os.path.abspath(os.path.dirname(__file__))
         os.system(f"cp {cdir}/__init__.py {cdir}/__init__.py.orig")
         copy_litepcie_software(dst)


### PR DESCRIPTION
these have a 35T FPGA, so a different PnR and boundary scan gateware is required. This variant also has less BRAM so we adjust the DMA buffer sizes accordingly.