### PR TITLE
DMA Mask Fixes

### DIFF
--- a/software/litepcie-kernel-module/main.c
+++ b/software/litepcie-kernel-module/main.c
@@ -32,6 +32,7 @@
 #include <linux/poll.h>
 #include <linux/cdev.h>
 #include <linux/platform_device.h>
+#include <linux/version.h>
 
 #include "litepcie.h"
 #include "csr.h"
@@ -1341,7 +1342,11 @@ static int litepcie_pci_probe(struct pci_dev *dev, const struct pci_device_id *i
 	dev_info(&dev->dev, "Version %s\n", fpga_identifier);
 
 	pci_set_master(dev);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 18, 0)
 	ret = pci_set_dma_mask(dev, DMA_BIT_MASK(32));
+#else
+	ret = dma_set_mask(&dev->dev, DMA_BIT_MASK(32));
+#endif
 	if (ret) {
 		dev_err(&dev->dev, "Failed to set DMA mask\n");
 		goto fail1;

--- a/software/litepcie-kernel-module/main.c
+++ b/software/litepcie-kernel-module/main.c
@@ -38,6 +38,7 @@
 #include "csr.h"
 #include "config.h"
 #include "flags.h"
+#include "soc.h"
 
 #define NV_DMA
 
@@ -1343,9 +1344,9 @@ static int litepcie_pci_probe(struct pci_dev *dev, const struct pci_device_id *i
 
 	pci_set_master(dev);
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 18, 0)
-	ret = pci_set_dma_mask(dev, DMA_BIT_MASK(32));
+	ret = pci_set_dma_mask(dev, DMA_BIT_MASK(DMA_ADDR_WIDTH));
 #else
-	ret = dma_set_mask(&dev->dev, DMA_BIT_MASK(32));
+	ret = dma_set_mask(&dev->dev, DMA_BIT_MASK(DMA_ADDR_WIDTH));
 #endif
 	if (ret) {
 		dev_err(&dev->dev, "Failed to set DMA mask\n");


### PR DESCRIPTION
This fixes a deprecated API on Linux 5.18. It also adds a speculative fix to set the `DMA_BIT_MASK` to `DMA_ADDR_WIDTH` based on my understanding of: https://www.kernel.org/doc/Documentation/DMA-API-HOWTO.txt